### PR TITLE
Correct return code handling in scripts/CI

### DIFF
--- a/build
+++ b/build
@@ -18,6 +18,8 @@ pushd "$SCRIPT_PATH" > /dev/null
 
 # build the executable with Maven
 mvn package "$@"
+return_code=$?
 
 # change the working directory back to where we came from
 popd > /dev/null
+exit $return_code

--- a/build
+++ b/build
@@ -17,7 +17,7 @@ popd > /dev/null
 pushd "$SCRIPT_PATH" > /dev/null
 
 # build the executable with Maven
-mvn package
+mvn package "$@"
 
 # change the working directory back to where we came from
 popd > /dev/null

--- a/run_mjtests.sh
+++ b/run_mjtests.sh
@@ -13,6 +13,8 @@ cp -r ./mjtest-files/* ./mjtest/tests/
 
 # call mjtest with the specified mode
 ./mjtest/mjt.py --log_level  error --ci_testing --parallel $1
+return_code=$?
 
 # cleanup
 rm -rf ./mjtest/tests/*
+exit $return_code


### PR DESCRIPTION
The CI should actually fail if there are failing tests (based on #35)