### PR TITLE
fix: Void type is not compatible to anything

### DIFF
--- a/src/main/java/edu/kit/compiler/data/DataType.java
+++ b/src/main/java/edu/kit/compiler/data/DataType.java
@@ -80,14 +80,17 @@ public class DataType {
      * given other data type.
      * 
      * A data type can be assigned to another data type if both data types are
-     * equal or one or both of the data types are Any.
+     * equal or one or both of the data types are Any. The Void data type is
+     * not compatible to any data type (not even itself).
      */
     public boolean isCompatibleTo(DataType other) {
-        if (type == DataTypeClass.Any || other.type == DataTypeClass.Any) {
+        if (type == DataTypeClass.Void || other.type == DataTypeClass.Void) {
+            return false;
+        } else if (type == DataTypeClass.Any || other.type == DataTypeClass.Any) {
             return true;
+        } else {
+            return equals(other);
         }
-
-        return equals(other);
     }
 
     @Override
@@ -136,6 +139,8 @@ public class DataType {
             );
         case Void:
             return "void";
+        case Any:
+            return "<any>";
         default:
             throw new IllegalStateException("unsupported data type");
         }

--- a/src/test/java/edu/kit/compiler/semantic/DetailedNameTypeAstVisitorSystem.java
+++ b/src/test/java/edu/kit/compiler/semantic/DetailedNameTypeAstVisitorSystem.java
@@ -2,6 +2,7 @@ package edu.kit.compiler.semantic;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Optional;
@@ -196,6 +197,39 @@ public class DetailedNameTypeAstVisitorSystem {
         DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
 
         assertThrows(SemanticException.class, () -> program.accept(visitor));
+    }
+
+    @Test
+    public void testSystemCall_Void() {
+        NamespaceMapper namespaceMapper = new NamespaceMapper();
+        StringTable stringTable = new StringTable();
+
+        ClassNode _class;
+        MethodInvocationExpressionNode methodInvocation;
+        ProgramNode program = new ProgramNode(0, 0, Arrays.asList(
+            (_class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
+                new DynamicMethodNode(0, 0, new DataType(DataTypeClass.Void), stringTable.insert("methodA"), Arrays.asList(), Optional.empty(),
+                    new BlockStatementNode(0, 0, Arrays.asList(
+                        new ExpressionStatementNode(0, 0,
+                            (methodInvocation = new MethodInvocationExpressionNode(0, 0, Optional.of(
+                                new FieldAccessExpressionNode(0, 0,
+                                    new IdentifierExpressionNode(0, 0, stringTable.insert("System"), false),
+                                stringTable.insert("out"), false)
+                            ), stringTable.insert("println"), Arrays.asList(
+                                new MethodInvocationExpressionNode(0, 0, Optional.empty(), stringTable.insert("methodA"), Arrays.asList(), false)
+                            ), false)),
+                        false)
+                    ), false),
+                false)
+            ), false))
+        ), false);
+
+        initializeNamespace(namespaceMapper, _class);
+
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+
+        assertThrows(SemanticException.class, () -> program.accept(visitor));
+        assertTrue(methodInvocation.isHasError());
     }
 
 }


### PR DESCRIPTION
Prevents using void method result where any type is allowed as argument.
```
void foo() { }
System.out.println(foo());
```

Prevents comparison of two void method results with variable type operators.
```
void foo() { }
foo() == foo();
```