### PR TITLE
fix: field access is not allowed in static methods

### DIFF
--- a/src/test/java/edu/kit/compiler/semantic/DetailedNameTypeAstVisitorSystem.java
+++ b/src/test/java/edu/kit/compiler/semantic/DetailedNameTypeAstVisitorSystem.java
@@ -135,6 +135,39 @@ public class DetailedNameTypeAstVisitorSystem {
     }
 
     @Test
+    public void testSystemCall_ShadowedByFieldStaticMethod() {
+        NamespaceMapper namespaceMapper = new NamespaceMapper();
+        StringTable stringTable = new StringTable();
+
+        ClassNode _class;
+        ProgramNode program = new ProgramNode(0, 0, Arrays.asList(
+            (_class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(
+                new ClassNode.ClassNodeField(0, 0, new DataType(stringTable.insert("ClassA")), stringTable.insert("System"), false)
+            ), Arrays.asList(
+                new StaticMethodNode(0, 0, new DataType(DataTypeClass.Void), stringTable.insert("methodA"), Arrays.asList(), Optional.empty(),
+                    new BlockStatementNode(0, 0, Arrays.asList(
+                        new ExpressionStatementNode(0, 0,
+                            new MethodInvocationExpressionNode(0, 0, Optional.of(
+                                new FieldAccessExpressionNode(0, 0,
+                                    new IdentifierExpressionNode(0, 0, stringTable.insert("System"), false),
+                                stringTable.insert("out"), false)
+                            ), stringTable.insert("println"), Arrays.asList(
+                                new ValueExpressionNode(0, 0, ValueExpressionType.IntegerLiteral, Literal.ofValue(17), false)
+                            ), false),
+                        false)
+                    ), false),
+                false)
+            ), Arrays.asList(), false))
+        ), false);
+
+        initializeNamespace(namespaceMapper, _class);
+
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+
+        assertThrows(SemanticException.class, () -> program.accept(visitor));
+    }
+
+    @Test
     public void testSystemCall_ShadowedByParameter() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();


### PR DESCRIPTION
Before, the field was not defined, now it is forbidden to access it. Makes `System` field shadow stdlib in static methods as well.