### PR TITLE
Fix subtle bug in lexing of comments

### DIFF
--- a/src/main/java/edu/kit/compiler/lexer/Lexer.java
+++ b/src/main/java/edu/kit/compiler/lexer/Lexer.java
@@ -240,7 +240,7 @@ public final class Lexer implements Iterator<Token> {
             reader.next();
             reader.next();
 
-            while (reader.peek() != '*' || reader.getNext() != '/') {
+            while (reader.peek() != '*' || reader.previewNext() != '/') {
                 if (reader.peek() == '/' && reader.getNext() == '*') {
                     logger.warn(line, column, "found opening comment inside of comment");
                 } else if (Character.isEndOfStream(reader.peek())) {
@@ -249,6 +249,8 @@ public final class Lexer implements Iterator<Token> {
                     reader.next();
                 }
             }
+
+            reader.next();
             reader.next();
             return true;
         } else {

--- a/src/main/java/edu/kit/compiler/lexer/Lexer.java
+++ b/src/main/java/edu/kit/compiler/lexer/Lexer.java
@@ -234,15 +234,16 @@ public final class Lexer implements Iterator<Token> {
      * @return true if a comment was skipped, false otherwise.
      */
     private boolean skipComment() {
-        if (reader.peek() == '/' && reader.previewNext() == '*') {
+        if (Character.isCommentStart(reader.peek(), reader.previewNext())) {
             int line = reader.getLine();
             int column = reader.getColumn();
             reader.next();
             reader.next();
 
-            while (reader.peek() != '*' || reader.previewNext() != '/') {
-                if (reader.peek() == '/' && reader.getNext() == '*') {
-                    logger.warn(line, column, "found opening comment inside of comment");
+            while (!Character.isCommentEnd(reader.peek(), reader.previewNext())) {
+                if (Character.isCommentStart(reader.peek(), reader.previewNext())) {
+                    logger.warn(reader.getLine(), reader.getColumn(),
+                        "found opening comment inside of comment");
                 } else if (Character.isEndOfStream(reader.peek())) {
                     throw new LexException(line, column, "unclosed comment");
                 } else {

--- a/src/test/java/edu/kit/compiler/lexer/LexerTest.java
+++ b/src/test/java/edu/kit/compiler/lexer/LexerTest.java
@@ -208,6 +208,12 @@ public class LexerTest {
     }
 
     @Test
+    public void testWeirdComment() {
+        var lexer = new Lexer(getReader("/***/"));
+        assertEquals(EndOfStream, lexer.getNextToken().getType());
+    }
+
+    @Test
     public void testWebsiteExample() {
         var stream = classLoader.getResourceAsStream("edu/kit/compiler/lexer/example.java");
         var lexer = new Lexer(new BufferedReader(new InputStreamReader(stream)));


### PR DESCRIPTION
The new lexer introduced a bug, where closing comments delimiters would be ignored if they were preceded by an asterisk (as in `/***/`).