### PR TITLE
Implement Firm type construction

### DIFF
--- a/src/main/java/edu/kit/compiler/JavaEasyCompiler.java
+++ b/src/main/java/edu/kit/compiler/JavaEasyCompiler.java
@@ -14,6 +14,7 @@ import edu.kit.compiler.semantic.ErrorHandler;
 import edu.kit.compiler.semantic.NamespaceGatheringVisitor;
 import edu.kit.compiler.semantic.NamespaceMapper;
 import edu.kit.compiler.semantic.SemanticChecks;
+import edu.kit.compiler.transform.Lower;
 import edu.kit.compiler.transform.TypeMapper;
 import firm.Dump;
 import firm.Firm;
@@ -165,7 +166,8 @@ public class JavaEasyCompiler {
             );
 
             // todo this is debug code, remember to remove
-            var _typeMapper = new TypeMapper(namespaceMapper, stringTable);
+            var typeMapper = new TypeMapper(namespaceMapper, stringTable);
+            Lower.lowerMethods(typeMapper);
             Dump.dumpTypeGraph("type-system.vcg");
 
             return Result.Ok;

--- a/src/main/java/edu/kit/compiler/JavaEasyCompiler.java
+++ b/src/main/java/edu/kit/compiler/JavaEasyCompiler.java
@@ -1,12 +1,29 @@
 package edu.kit.compiler;
 
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.Reader;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionGroup;
+import org.apache.commons.cli.Options;
+
 import edu.kit.compiler.data.CompilerException;
 import edu.kit.compiler.data.Token;
 import edu.kit.compiler.data.TokenType;
 import edu.kit.compiler.data.ast_nodes.ProgramNode;
 import edu.kit.compiler.lexer.Lexer;
 import edu.kit.compiler.lexer.StringTable;
-import org.apache.commons.cli.*;
+import edu.kit.compiler.logger.Logger;
+import edu.kit.compiler.logger.Logger.Verbosity;
 import edu.kit.compiler.parser.Parser;
 import edu.kit.compiler.parser.PrettyPrintAstVisitor;
 import edu.kit.compiler.semantic.DetailedNameTypeAstVisitor;
@@ -14,14 +31,7 @@ import edu.kit.compiler.semantic.ErrorHandler;
 import edu.kit.compiler.semantic.NamespaceGatheringVisitor;
 import edu.kit.compiler.semantic.NamespaceMapper;
 import edu.kit.compiler.semantic.SemanticChecks;
-import edu.kit.compiler.transform.Lower;
-import edu.kit.compiler.transform.TypeMapper;
-import firm.Dump;
 import firm.Firm;
-import edu.kit.compiler.logger.Logger;
-import edu.kit.compiler.logger.Logger.Verbosity;
-
-import java.io.*;
 
 public class JavaEasyCompiler {
     /**
@@ -165,10 +175,7 @@ public class JavaEasyCompiler {
                 Firm.getMinorVersion(), Firm.getMajorVersion()
             );
 
-            // todo this is debug code, remember to remove
-            var typeMapper = new TypeMapper(namespaceMapper, stringTable);
-            Lower.lowerMethods(typeMapper);
-            Dump.dumpTypeGraph("type-system.vcg");
+            // todo actually implement code generation
 
             return Result.Ok;
         } catch (CompilerException e) {

--- a/src/main/java/edu/kit/compiler/semantic/NamespaceMapper.java
+++ b/src/main/java/edu/kit/compiler/semantic/NamespaceMapper.java
@@ -4,25 +4,26 @@ import edu.kit.compiler.data.ast_nodes.ClassNode;
 import edu.kit.compiler.data.ast_nodes.MethodNode;
 import lombok.Data;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class NamespaceMapper {
 
-    private final Map<Integer, ClassNamespace> symbolTableMap = new HashMap<>();
+    private final Map<Integer, ClassNamespace> namespaceMap = new LinkedHashMap<>();
 
     @Data
     public static class ClassNamespace {
         private final ClassNode classNodeRef;
         private final Map<Integer, MethodNode.DynamicMethodNode> dynamicMethods = new HashMap<>();
         private final Map<Integer, MethodNode.StaticMethodNode> staticMethods = new HashMap<>();
-        private final Map<Integer, ClassNode.ClassNodeField> classSymbols = new HashMap<>();
+        private final Map<Integer, ClassNode.ClassNodeField> classSymbols = new LinkedHashMap<>();
 
         public ClassNamespace(ClassNode classNodeRef) {
             this.classNodeRef = classNodeRef;
         }
     }
-
 
     /**
      * Create a new symbol table once a new class is visited during recursive descent.
@@ -32,12 +33,12 @@ public class NamespaceMapper {
      */
     public ClassNamespace insertClassNode(ClassNode classNode) {
         int classNodeName = classNode.getName();
-        if (this.symbolTableMap.containsKey(classNodeName)) {
+        if (this.namespaceMap.containsKey(classNodeName)) {
             // this should never happend make sure to fix all issues where the same class would get added twice
             throw new SemanticException("Cannot insert same class twice into namespace map", classNode);
         }
         ClassNamespace classNamespace = new ClassNamespace(classNode);
-        this.symbolTableMap.put(classNodeName, classNamespace);
+        this.namespaceMap.put(classNodeName, classNamespace);
 
         return classNamespace;
     }
@@ -48,7 +49,7 @@ public class NamespaceMapper {
      * @return the namespace that is assigned to this node
      */
     public ClassNamespace getClassNamespace(ClassNode node) {
-        return this.symbolTableMap.get(node.getName());
+        return this.namespaceMap.get(node.getName());
     }
 
     /**
@@ -57,7 +58,7 @@ public class NamespaceMapper {
      * @return the namespace that is assigned to this node
      */
     public ClassNamespace getClassNamespace(int nodeId) {
-        return this.symbolTableMap.get(nodeId);
+        return this.namespaceMap.get(nodeId);
     }
 
     /**
@@ -66,7 +67,15 @@ public class NamespaceMapper {
      * @param nodeId class node id
      */
     public boolean containsClassNamespace(int nodeId) {
-        return this.symbolTableMap.containsKey(nodeId);
+        return this.namespaceMap.containsKey(nodeId);
     }
 
+    /**
+     * Get an immutable view of all namespaces in this mapper.
+     * 
+     * @return an unmodifiable map of all namespaces.
+     */
+    public Map<Integer, ClassNamespace> getNamespaceMap() {
+        return Collections.unmodifiableMap(namespaceMap);
+    }
 }

--- a/src/main/java/edu/kit/compiler/transform/Lower.java
+++ b/src/main/java/edu/kit/compiler/transform/Lower.java
@@ -1,0 +1,26 @@
+package edu.kit.compiler.transform;
+
+import firm.Backend;
+import firm.Ident;
+import firm.Program;
+
+public class Lower {
+    /**
+     * Moves all methods in the given `TypeMapper` to the program's global type.
+     * Also makes sure their labels are unique and comply with the conventions
+     * of the target architecture.
+     */
+    public static void lowerMethods(TypeMapper typeMapper) {
+        var globalType = Program.getGlobalType();
+        var uid = 0;
+
+        for (var entry : typeMapper.getClassEntries()) {
+            var className = entry.getClassType().getName();
+            for (var method : entry.getMethods()) {
+                var label = String.format("%s_%s_%s", className, method.getName(), uid++);
+                method.setLdIdent(Ident.mangleGlobal(label));
+                method.setOwner(globalType);
+            }
+        }
+    }
+}

--- a/src/main/java/edu/kit/compiler/transform/Lower.java
+++ b/src/main/java/edu/kit/compiler/transform/Lower.java
@@ -1,6 +1,5 @@
 package edu.kit.compiler.transform;
 
-import firm.Backend;
 import firm.Ident;
 import firm.Program;
 

--- a/src/main/java/edu/kit/compiler/transform/TypeMapper.java
+++ b/src/main/java/edu/kit/compiler/transform/TypeMapper.java
@@ -238,17 +238,17 @@ public final class TypeMapper {
          * and dynamic method in the given namespace.
          */
         private <T extends MethodNode> void constructMethods(
-            ClassNode classNode, Map<Integer, T> methodNodes, boolean is_static
+            ClassNode classNode, Map<Integer, T> methodNodes, boolean isStatic
         ) {
             for (var methodNode : methodNodes.values()) {
                 var methodName = stringTable.retrieve(methodNode.getName());
-                var methodType = getMethodType(methodNode, is_static);
+                var methodType = getMethodType(methodNode, isStatic);
 
                 var methodEntity = new Entity(classType, methodName, methodType);
                 methodEntity.setVisibility(ir_visibility.ir_visibility_local);
                 methods.put(methodNode.getName(), methodEntity);
 
-                if (is_static) {
+                if (isStatic) {
                     if (mainMethod != null || !methodName.equals("main")) {
                         throw new IllegalStateException(
                             "found illegal static method; program is invalid");
@@ -281,8 +281,8 @@ public final class TypeMapper {
         /**
          * Only called during construction.
          */
-        private MethodType getMethodType(MethodNode method, boolean is_static) {
-            var parameterTypes = getParameterTypes(method.getParameters(), is_static);
+        private MethodType getMethodType(MethodNode method, boolean isStatic) {
+            var parameterTypes = getParameterTypes(method.getParameters(), isStatic);
             var returnType = getReturnType(method.getType());
             return new MethodType(parameterTypes, returnType);
         }
@@ -300,13 +300,13 @@ public final class TypeMapper {
 
         /**
          * Only called during construction. Adds an artificial first parameter
-         * for `this` if `is_static is false.
+         * for `this` if `isStatic is false.
          */
-        private Type[] getParameterTypes(List<MethodNodeParameter> parameters, boolean is_static) {
-            var offset = is_static ? 0 : 1;
+        private Type[] getParameterTypes(List<MethodNodeParameter> parameters, boolean isStatic) {
+            var offset = isStatic ? 0 : 1;
             var parameterTypes = new Type[parameters.size() + offset];
 
-            if (!is_static) {
+            if (!isStatic) {
                 parameterTypes[0] = new PointerType(classType);
             }
 

--- a/src/main/java/edu/kit/compiler/transform/TypeMapper.java
+++ b/src/main/java/edu/kit/compiler/transform/TypeMapper.java
@@ -1,0 +1,198 @@
+package edu.kit.compiler.transform;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import edu.kit.compiler.data.DataType;
+import edu.kit.compiler.data.DataType.DataTypeClass;
+import edu.kit.compiler.data.ast_nodes.ClassNode;
+import edu.kit.compiler.data.ast_nodes.MethodNode.DynamicMethodNode;
+import edu.kit.compiler.data.ast_nodes.MethodNode.MethodNodeParameter;
+import edu.kit.compiler.lexer.StringTable;
+import edu.kit.compiler.semantic.NamespaceMapper;
+import edu.kit.compiler.semantic.NamespaceMapper.ClassNamespace;
+import firm.ClassType;
+import firm.Entity;
+import firm.MethodType;
+import firm.Mode;
+import firm.PointerType;
+import firm.PrimitiveType;
+import firm.Type;
+import firm.bindings.binding_typerep.ir_visibility;
+import lombok.Getter;
+
+
+/**
+ * Provides the type system for a MiniJava program. Each class is mapped to a
+ * `ClassEntry`.
+ */
+public final class TypeMapper {
+
+    private final Map<Integer, ClassEntry> classes = new HashMap<>();
+
+    private final StringTable stringTable;
+    private final TypeFactory typeFactory;
+
+    /**
+     * Set up the type system for a MiniJava program.
+     * 
+     * @param namespaceMapper the class namespaces of the program.
+     * @param stringTable the `stringTable` used for the program.
+     */
+    public TypeMapper(NamespaceMapper namespaceMapper, StringTable stringTable) {
+        this.stringTable = stringTable;
+        this.typeFactory = new TypeFactory();
+
+        for (var namespace : namespaceMapper.getNamespaceMap().values()) {
+            var entry = new ClassEntry(namespace);
+            this.classes.put(namespace.getClassNodeRef().getName(), entry);
+        }
+    }
+
+    /**
+     * Returns the corresponding Firm type for the given data type.
+     * 
+     * @param type
+     * @return
+     */
+    public Type getDataType(DataType type) {
+        return typeFactory.getDataType(type);
+    }
+
+    public ClassEntry getClassEntry(int classId) {
+        return classes.get(classId);
+    }
+
+    /**
+     * Represents all types and entities related to a single class in a MiniJava
+     * program. This includes the type of the class itself, as well as an entity
+     * for each field and method of the class. Types of fields and methods can
+     * be accessed via the corresponding entities.
+     */
+    public final class ClassEntry {
+        @Getter
+        private final ClassType type;
+        private final Map<Integer, Entity> fields = new HashMap<>();
+        private final Map<Integer, Entity> methods = new HashMap<>();
+
+        private ClassEntry(ClassNamespace namespace) {
+            this.type = typeFactory.getClassType(namespace.getClassNodeRef());
+
+            // Create and register entity for each field of the class
+            constructFields(namespace);
+
+            // Create and register entity for each dynamic method of the class
+            constructMethods(namespace);
+
+            // ? maybe do later (after possible optimizations)
+            type.layoutFields();
+            type.finishLayout();
+        }
+
+        /**
+         * Returns the Firm entity representing the given field.
+         * @param fieldId
+         * @return
+         */
+        public Entity getField(int fieldId) {
+            return fields.get(fieldId);
+        }
+
+        /**
+         * Returns the Firm entity representing the given method.
+         * @param methodId
+         * @return
+         */
+        public Entity getMethod(int methodId) {
+            return methods.get(methodId);
+        }
+
+        private void constructFields(ClassNamespace namespace) {
+            for (var fieldNode : namespace.getClassSymbols().values()) {
+                var fieldName = stringTable.retrieve(fieldNode.getName());
+                var fieldType = typeFactory.getDataType(fieldNode.getType());
+
+                var fieldEntity = new Entity(type, fieldName, fieldType);
+                fieldEntity.setVisibility(ir_visibility.ir_visibility_local);
+                fields.put(fieldNode.getName(), fieldEntity);
+            }
+        }
+
+        private void constructMethods(ClassNamespace namespace) {
+            var classNode = namespace.getClassNodeRef();
+            for (var methodNode : namespace.getDynamicMethods().values()) {
+                var methodName = stringTable.retrieve(methodNode.getName());
+                var methodType = typeFactory.getMethodType(classNode, methodNode);
+
+                var methodEntity = new Entity(type, methodName, methodType);
+                methodEntity.setVisibility(ir_visibility.ir_visibility_local);
+                methods.put(methodNode.getName(), methodEntity);
+            }
+        }
+    }
+
+    private final class TypeFactory {
+        private final Map<Integer, ClassType> userTypes = new HashMap<>();
+
+        private final Type booleanType = new PrimitiveType(Mode.getBu());
+        private final Type integerType = new PrimitiveType(Mode.getIs());
+
+        private ClassType getClassType(ClassNode class_) {
+            return getUserType(new DataType(class_.getName()));
+        }
+
+        private MethodType getMethodType(ClassNode classNode, DynamicMethodNode method) {
+            var parameterTypes = getParameterTypes(classNode, method.getParameters());
+            var returnType = getReturnType(method.getType());
+            return new MethodType(parameterTypes, returnType);
+        }
+
+        private Type getDataType(DataType type) {
+            return switch (type.getType()) {
+                case Boolean -> booleanType;
+                case Int -> integerType;
+                case Array -> {
+                    var innerType = getDataType(type.getInnerType().get());
+                    yield new PointerType(innerType);
+                }
+                case UserDefined -> new PointerType(getUserType(type)); 
+                case Void, Any -> throw new IllegalArgumentException(
+                    String.format("can't construct type for %s", type.getType())
+                );
+                default -> throw new IllegalStateException("unsupported data type");
+            };
+        }
+
+        private ClassType getUserType(DataType type) {
+            assert type.getType() == DataTypeClass.UserDefined;
+
+            var classId = type.getIdentifier().get();
+            var classType = userTypes.get(classId);
+            if (classType == null) {
+                var className = stringTable.retrieve(classId);
+                classType = new ClassType(className);
+                userTypes.put(classId, classType);
+            }
+
+            return classType;
+        }
+
+        private Type[] getReturnType(DataType type) {
+            return switch (type.getType()) {
+                case Void -> new Type[] {};
+                default   -> new Type[] { getDataType(type) };
+            };
+        }
+
+        private Type[] getParameterTypes(ClassNode class_, List<MethodNodeParameter> parameters) {
+            var parameterTypes = new Type[parameters.size() + 1];
+            parameterTypes[0] = new PointerType(getClassType(class_));
+            for (int i = 0; i < parameters.size(); i++) {
+                parameterTypes[i+1] = getDataType(parameters.get(i).getType());
+            }
+
+            return parameterTypes;
+        }
+    }
+}

--- a/src/main/java/edu/kit/compiler/transform/TypeMapper.java
+++ b/src/main/java/edu/kit/compiler/transform/TypeMapper.java
@@ -1,5 +1,7 @@
 package edu.kit.compiler.transform;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -106,6 +108,15 @@ public final class TypeMapper {
     }
 
     /**
+     * Returns an immutable view of all classes registered in the type mapper.
+     * 
+     * @return an unmodifiable collection of all `ClassEntry`s
+     */
+    public Collection<ClassEntry> getClassEntries() {
+        return Collections.unmodifiableCollection(classes.values());
+    }
+
+    /**
      * Represents all types and entities related to a single class in a MiniJava
      * program. This includes the type of the class itself, as well as an entity
      * for each field and method of the class. Types of fields and methods can
@@ -143,6 +154,15 @@ public final class TypeMapper {
         }
 
         /**
+         * Returns an immutable view of all field entities of this class.
+         * 
+         * @return an unmodifiable collection of all field `Entity`s
+         */
+        public Collection<Entity> getFields() {
+            return Collections.unmodifiableCollection(fields.values());
+        }
+
+        /**
          * Returns the Firm entity representing the method with the given name.
          * 
          * @param methodId the name of the method whose entity is to be returned
@@ -160,6 +180,15 @@ public final class TypeMapper {
          */
         public Entity getMethod(MethodNode method) {
             return getMethod(method.getName());
+        }
+
+        /**
+         * Returns an immutable view of all method entities of this class.
+         * 
+         * @return an unmodifiable collection of all method `Entity`s
+         */
+        public Collection<Entity> getMethods() {
+            return Collections.unmodifiableCollection(methods.values());
         }
 
         /**
@@ -217,7 +246,6 @@ public final class TypeMapper {
          * user defined types if necessary.
          */
         private Type initDataType(DataType type) {
-
             return switch (type.getType()) {
                 case Array -> {
                     var innerType = initDataType(type.getInnerType().get());

--- a/src/main/java/edu/kit/compiler/transform/TypeMapper.java
+++ b/src/main/java/edu/kit/compiler/transform/TypeMapper.java
@@ -1,5 +1,6 @@
 package edu.kit.compiler.transform;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -204,6 +205,7 @@ public final class TypeMapper {
 
         private MethodType getMethodType(MethodNode method, boolean is_static) {
             var parameterTypes = getParameterTypes(method.getParameters(), is_static);
+            System.out.println(stringTable.retrieve(method.getName()) + " " + Arrays.toString(parameterTypes));
             var returnType = getReturnType(method.getType());
             return new MethodType(parameterTypes, returnType);
         }
@@ -219,11 +221,11 @@ public final class TypeMapper {
             var offset = is_static ? 0 : 1;
             var parameterTypes = new Type[parameters.size() + offset];
 
-            if (is_static) {
+            if (!is_static) {
                 parameterTypes[0] = new PointerType(classType);
             }
 
-            for (int i = offset; i < parameters.size(); i++) {
+            for (int i = 0; i < parameters.size(); i++) {
                 parameterTypes[i + offset] = getDataType(parameters.get(i).getType());
             }
 

--- a/src/main/java/edu/kit/compiler/transform/TypeMapper.java
+++ b/src/main/java/edu/kit/compiler/transform/TypeMapper.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import edu.kit.compiler.data.DataType;
 import edu.kit.compiler.data.ast_nodes.ClassNode;
@@ -250,7 +249,7 @@ public final class TypeMapper {
                 methods.put(methodNode.getName(), methodEntity);
 
                 if (is_static) {
-                    if (mainMethod != null || methodName != "main") {
+                    if (mainMethod != null || !methodName.equals("main")) {
                         throw new IllegalStateException(
                             "found illegal static method; program is invalid");
                     } else {


### PR DESCRIPTION
This is an initial implementation for converting MiniJava types to Firm types. It is supposed to serve as a starting point for further functionality, as it also generates method entities necessary to generate actual code graphs.