### PR TITLE
Remove unnecessary `lowerForTarget`

### DIFF
--- a/src/main/java/edu/kit/compiler/transform/Lower.java
+++ b/src/main/java/edu/kit/compiler/transform/Lower.java
@@ -17,7 +17,6 @@ public class Lower {
     public static void lower(TypeMapper typeMapper) {
         lowerMethods(typeMapper);
         setMainMethod(typeMapper);
-        Backend.lowerForTarget();
         Util.lowerSels();
     }
 


### PR DESCRIPTION
`Backend.lowerForTarget` resolves only functionality we are not using. In addition it performs some optimizations which may conflict with the optimizations we have implemented.