### PR TITLE
Phi resolver and block ordering

### DIFF
--- a/mjtest-files/compile/Permutation.mj
+++ b/mjtest-files/compile/Permutation.mj
@@ -1,0 +1,19 @@
+class Permutation {
+    public static void main(String[] args) {
+        int a = 1;
+        int b = 2;
+        int c = 3;
+        int d = 4;
+        while (a < 4) {
+            int tmp = a;
+            a = b;
+            b = c;
+            c = d;
+            d = tmp;
+        }
+        System.out.println(a);
+        System.out.println(b);
+        System.out.println(c);
+        System.out.println(d);
+    }
+}

--- a/mjtest-files/compile/PermutationComplex.mj
+++ b/mjtest-files/compile/PermutationComplex.mj
@@ -1,0 +1,25 @@
+class Permutation {
+    public static void main(String[] args) {
+        int c1 = 1;
+        int c2 = 2;
+        int c3 = 3;
+        int a = 4;
+        int b = 5;
+        int c = 6;
+        while (c1 < 3) {
+            a = c1;
+            b = c1;
+            c = c2;
+            int tmp = c1;
+            c1 = c2;
+            c2 = c3;
+            c3 = tmp;
+        }
+        System.out.println(c1);
+        System.out.println(c2);
+        System.out.println(c3);
+        System.out.println(a);
+        System.out.println(b);
+        System.out.println(c);
+    }
+}

--- a/src/main/java/edu/kit/compiler/codegen/BasicBlocks.java
+++ b/src/main/java/edu/kit/compiler/codegen/BasicBlocks.java
@@ -52,6 +52,10 @@ public class BasicBlocks {
         return blocks.values();
     }
 
+    public BlockEntry getStartBlock() {
+        return blocks.get(graph.getStartBlock().getNr());
+    }
+
     @Override
     public String toString() {
         return graph.getEntity().getName() + ": " + blocks.toString();

--- a/src/main/java/edu/kit/compiler/codegen/BasicBlocks.java
+++ b/src/main/java/edu/kit/compiler/codegen/BasicBlocks.java
@@ -118,9 +118,9 @@ public class BasicBlocks {
             var condition = exitCondition.get();
             if (node.getPred().getOpCode() == ir_opcode.iro_Cond) {
                 if (node.getNum() == Cond.pnTrue) {
-                    condition.setTrueBlock(entry);
+                    condition.setTrueBlock(entry.getBlockId());
                 } else if (node.getNum() == Cond.pnFalse) {
-                    condition.setFalseBlock(entry);
+                    condition.setFalseBlock(entry.getBlockId());
                 } else {
                     throw new IllegalStateException();
                 }
@@ -137,7 +137,7 @@ public class BasicBlocks {
 
             var entry = getEntry(block);
             var condition = exitCondition.get();
-            condition.setTrueBlock(entry);
+            condition.setTrueBlock(entry.getBlockId());
         }
 
         /**

--- a/src/main/java/edu/kit/compiler/codegen/BasicBlocks.java
+++ b/src/main/java/edu/kit/compiler/codegen/BasicBlocks.java
@@ -31,11 +31,11 @@ public class BasicBlocks {
 
     private final HashMap<Integer, BlockEntry> blocks = new HashMap<>();
 
-    private int currentBlockId;
+    private int currentLabel;
 
-    public BasicBlocks(Graph graph, int blockId) {
+    public BasicBlocks(Graph graph, int jumpLabel) {
         this.graph = graph;
-        this.currentBlockId = blockId;
+        this.currentLabel = jumpLabel;
     }
 
     /**
@@ -45,11 +45,11 @@ public class BasicBlocks {
     public BlockEntry getEntry(Node block) {
         assert block.getOpCode() == ir_opcode.iro_Block;
         return blocks.computeIfAbsent(block.getNr(),
-                n -> new BlockEntry((Block) block, newBlockId()));
+                n -> new BlockEntry((Block) block, newLabel()));
     }
 
-    public int newBlockId() {
-        return currentBlockId++;
+    public int newLabel() {
+        return currentLabel++;
     }
 
     public Collection<BlockEntry> getEntries() {
@@ -74,7 +74,7 @@ public class BasicBlocks {
         @Getter
         private final Block firmBlock;
         @Getter
-        private final int blockId;
+        private final int jumpLabel;
 
         private final List<Instruction> instructions = new ArrayList<>();
         private final List<PhiInstruction> phiInstructions = new ArrayList<>();
@@ -86,7 +86,7 @@ public class BasicBlocks {
          * Return the jump label of the block.
          */
         public int getLabel() {
-            return blockId;
+            return jumpLabel;
         }
 
         /**
@@ -132,9 +132,9 @@ public class BasicBlocks {
             var condition = exitCondition.get();
             if (node.getPred().getOpCode() == ir_opcode.iro_Cond) {
                 if (node.getNum() == Cond.pnTrue) {
-                    condition.setTrueBlock(entry.getBlockId());
+                    condition.setTrueBlock(entry.getJumpLabel());
                 } else if (node.getNum() == Cond.pnFalse) {
-                    condition.setFalseBlock(entry.getBlockId());
+                    condition.setFalseBlock(entry.getJumpLabel());
                 } else {
                     throw new IllegalStateException();
                 }
@@ -151,7 +151,7 @@ public class BasicBlocks {
 
             var entry = getEntry(block);
             var condition = exitCondition.get();
-            condition.setTrueBlock(entry.getBlockId());
+            condition.setTrueBlock(entry.getJumpLabel());
         }
 
         /**
@@ -179,7 +179,7 @@ public class BasicBlocks {
         public String toString() {
             var instructions = Stream.concat(getInstructions().stream(),
                     getExitInstructions().stream()).collect(Collectors.toList());
-            return String.format("(.L%d: %s, %s)", blockId, phiInstructions, instructions.toString());
+            return String.format("(.L%d: %s, %s)", jumpLabel, phiInstructions, instructions.toString());
         }
     }
 }

--- a/src/main/java/edu/kit/compiler/codegen/BasicBlocks.java
+++ b/src/main/java/edu/kit/compiler/codegen/BasicBlocks.java
@@ -73,7 +73,6 @@ public class BasicBlocks {
 
         @Getter
         private final Block firmBlock;
-        @Getter
         private final int jumpLabel;
 
         private final List<Instruction> instructions = new ArrayList<>();
@@ -132,9 +131,9 @@ public class BasicBlocks {
             var condition = exitCondition.get();
             if (node.getPred().getOpCode() == ir_opcode.iro_Cond) {
                 if (node.getNum() == Cond.pnTrue) {
-                    condition.setTrueBlock(entry.getJumpLabel());
+                    condition.setTrueBlock(entry.getLabel());
                 } else if (node.getNum() == Cond.pnFalse) {
-                    condition.setFalseBlock(entry.getJumpLabel());
+                    condition.setFalseBlock(entry.getLabel());
                 } else {
                     throw new IllegalStateException();
                 }
@@ -151,7 +150,7 @@ public class BasicBlocks {
 
             var entry = getEntry(block);
             var condition = exitCondition.get();
-            condition.setTrueBlock(entry.getJumpLabel());
+            condition.setTrueBlock(entry.getLabel());
         }
 
         /**

--- a/src/main/java/edu/kit/compiler/codegen/BasicBlocks.java
+++ b/src/main/java/edu/kit/compiler/codegen/BasicBlocks.java
@@ -31,6 +31,8 @@ public class BasicBlocks {
 
     private final HashMap<Integer, BlockEntry> blocks = new HashMap<>();
 
+    private int currentBlockId = 0;
+
     /**
      * Return the entry for the given Firm block. The caller must ensure that
      * the node is actually a block;
@@ -38,7 +40,11 @@ public class BasicBlocks {
     public BlockEntry getEntry(Node block) {
         assert block.getOpCode() == ir_opcode.iro_Block;
         return blocks.computeIfAbsent(block.getNr(),
-                n -> new BlockEntry((Block) block));
+                n -> new BlockEntry((Block) block, newBlockId()));
+    }
+
+    public int newBlockId() {
+        return currentBlockId++;
     }
 
     @Override
@@ -54,6 +60,8 @@ public class BasicBlocks {
 
         @Getter
         private final Block firmBlock;
+        @Getter
+        private final int blockId;
 
         private final List<Instruction> instructions = new ArrayList<>();
         private final List<PhiInstruction> phiInstructions = new ArrayList<>();
@@ -64,7 +72,7 @@ public class BasicBlocks {
          * Return the jump label of the block.
          */
         public int getLabel() {
-            return firmBlock.getNr();
+            return blockId;
         }
 
         /**
@@ -157,7 +165,7 @@ public class BasicBlocks {
         public String toString() {
             var instructions = Stream.concat(getInstructions().stream(),
                     getExitInstructions().stream()).collect(Collectors.toList());
-            return String.format("(%s, %s)", phiInstructions, instructions.toString());
+            return String.format("(.L%d: %s, %s)", blockId, phiInstructions, instructions.toString());
         }
     }
 }

--- a/src/main/java/edu/kit/compiler/codegen/BasicBlocks.java
+++ b/src/main/java/edu/kit/compiler/codegen/BasicBlocks.java
@@ -24,7 +24,6 @@ import lombok.RequiredArgsConstructor;
 /**
  * Represents the basic blocks of a function.
  */
-@RequiredArgsConstructor
 public class BasicBlocks {
 
     @Getter
@@ -32,7 +31,12 @@ public class BasicBlocks {
 
     private final HashMap<Integer, BlockEntry> blocks = new HashMap<>();
 
-    private int currentBlockId = 0;
+    private int currentBlockId;
+
+    public BasicBlocks(Graph graph, int blockId) {
+        this.graph = graph;
+        this.currentBlockId = blockId;
+    }
 
     /**
      * Return the entry for the given Firm block. The caller must ensure that

--- a/src/main/java/edu/kit/compiler/codegen/BasicBlocks.java
+++ b/src/main/java/edu/kit/compiler/codegen/BasicBlocks.java
@@ -2,6 +2,7 @@ package edu.kit.compiler.codegen;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -47,6 +48,10 @@ public class BasicBlocks {
         return currentBlockId++;
     }
 
+    public Collection<BlockEntry> getEntries() {
+        return blocks.values();
+    }
+
     @Override
     public String toString() {
         return graph.getEntity().getName() + ": " + blocks.toString();
@@ -66,6 +71,7 @@ public class BasicBlocks {
         private final List<Instruction> instructions = new ArrayList<>();
         private final List<PhiInstruction> phiInstructions = new ArrayList<>();
 
+        @Getter
         private Optional<ExitCondition> exitCondition = Optional.empty();
 
         /**

--- a/src/main/java/edu/kit/compiler/codegen/ExitCondition.java
+++ b/src/main/java/edu/kit/compiler/codegen/ExitCondition.java
@@ -27,12 +27,12 @@ public abstract class ExitCondition {
      * Sets the destination of the condition if it evaluates to true. Also used
      * to set the destination for an unconditional jump.
      */
-    public abstract void setTrueBlock(int blockId);
+    public abstract void setTrueBlock(int label);
 
     /**
      * Sets the destination of the condition if it evaluates to false.
      */
-    public abstract void setFalseBlock(int blockId);
+    public abstract void setFalseBlock(int label);
 
     /**
      * Replaces a destination block with a new block.
@@ -53,30 +53,30 @@ public abstract class ExitCondition {
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static final class UnconditionalJump extends ExitCondition {
-        private int blockId = -1;
+        private int label = -1;
 
         @Override
         public List<Instruction> getInstructions() {
-            assert blockId >= 0;
+            assert label >= 0;
             return List.of(Instruction.newJmp(
-                    Util.formatJmp("jmp", blockId), blockId)
+                    Util.formatJmp("jmp", label), label)
             );
         }
 
         @Override
-        public void setTrueBlock(int blockId) {
-            this.blockId = blockId;
+        public void setTrueBlock(int label) {
+            this.label = label;
         }
 
         @Override
-        public void setFalseBlock(int blockId) {
+        public void setFalseBlock(int label) {
             throw new UnsupportedOperationException();
         }
 
         @Override
         public void replaceBlock(int oldId, int newId) {
-            assert blockId == oldId;
-            blockId = newId;
+            assert label == oldId;
+            label = newId;
         }
 
         @Override
@@ -92,47 +92,47 @@ public abstract class ExitCondition {
         private final Operand.Source target;
         private final Operand.Source source;
 
-        private int trueBlockId = -1;
-        private int falseBlockId = -1;
+        private int trueLabel = -1;
+        private int falseLabel = -1;
 
         @Override
         public List<Instruction> getInstructions() {
-            assert trueBlockId >= 0 && falseBlockId >= 0;
+            assert trueLabel >= 0 && falseLabel >= 0;
 
             return switch (relation) {
-                case True -> new UnconditionalJump(trueBlockId).getInstructions();
-                case False -> new UnconditionalJump(falseBlockId).getInstructions();
-                case LessEqualGreater -> new UnconditionalJump(trueBlockId).getInstructions();
+                case True -> new UnconditionalJump(trueLabel).getInstructions();
+                case False -> new UnconditionalJump(falseLabel).getInstructions();
+                case LessEqualGreater -> new UnconditionalJump(trueLabel).getInstructions();
                 default -> List.of(
                         Instruction.newInput(
                                 Util.formatCmd("cmp", target.getSize(), source, target),
                                 getInputRegisters(source, target)),
                         Instruction.newJmp(
-                                Util.formatJmp(getJmpCmd(), trueBlockId),
-                                trueBlockId),
+                                Util.formatJmp(getJmpCmd(), trueLabel),
+                                trueLabel),
                         Instruction.newJmp(
-                                Util.formatJmp("jmp", falseBlockId),
-                                falseBlockId));
+                                Util.formatJmp("jmp", falseLabel),
+                                falseLabel));
             };
         }
 
         @Override
-        public void setTrueBlock(int blockId) {
-            this.trueBlockId = blockId;
+        public void setTrueBlock(int label) {
+            this.trueLabel = label;
         }
 
         @Override
-        public void setFalseBlock(int blockId) {
-            this.falseBlockId = blockId;
+        public void setFalseBlock(int label) {
+            this.falseLabel = label;
         }
 
         @Override
         public void replaceBlock(int oldId, int newId) {
-            if (trueBlockId == oldId) {
-                trueBlockId = newId;
+            if (trueLabel == oldId) {
+                trueLabel = newId;
             } else {
-                assert falseBlockId == oldId;
-                falseBlockId = newId;
+                assert falseLabel == oldId;
+                falseLabel = newId;
             }
         }
 

--- a/src/main/java/edu/kit/compiler/codegen/ExitCondition.java
+++ b/src/main/java/edu/kit/compiler/codegen/ExitCondition.java
@@ -39,6 +39,8 @@ public abstract class ExitCondition {
      */
     public abstract void replaceBlock(int oldId, int newId);
 
+    public abstract boolean isUnconditional();
+
     public static ExitCondition unconditional() {
         return new UnconditionalJump();
     }
@@ -75,6 +77,11 @@ public abstract class ExitCondition {
         public void replaceBlock(int oldId, int newId) {
             assert blockId == oldId;
             blockId = newId;
+        }
+
+        @Override
+        public boolean isUnconditional() {
+            return true;
         }
     }
 
@@ -127,6 +134,11 @@ public abstract class ExitCondition {
                 assert falseBlockId == oldId;
                 falseBlockId = newId;
             }
+        }
+
+        @Override
+        public boolean isUnconditional() {
+            return false;
         }
 
         private String getJmpCmd() {

--- a/src/main/java/edu/kit/compiler/codegen/InstructionSelection.java
+++ b/src/main/java/edu/kit/compiler/codegen/InstructionSelection.java
@@ -25,10 +25,10 @@ public final class InstructionSelection {
     @Getter
     private final BasicBlocks blocks;
 
-    private InstructionSelection(Graph graph) {
+    private InstructionSelection(Graph graph, int blockId) {
         // todo is this the idiomatic way of getting number of parameters
         var type = (MethodType) graph.getEntity().getType();
-        blocks = new BasicBlocks(graph);
+        blocks = new BasicBlocks(graph, blockId);
 
         var parameters = new ArrayList<RegisterSize>(type.getNParams());
         for (int i = 0; i < type.getNParams(); ++i) {
@@ -37,8 +37,8 @@ public final class InstructionSelection {
         matcher = new MatcherState(graph, parameters);
     }
 
-    public static InstructionSelection apply(Graph graph, PatternCollection patterns) {
-        var instance = new InstructionSelection(graph);
+    public static InstructionSelection apply(Graph graph, PatternCollection patterns, int blockId) {
+        var instance = new InstructionSelection(graph, blockId);
 
         var matchingVisitor = instance.new MatchingVisitor(patterns);
         graph.walkTopological(matchingVisitor);

--- a/src/main/java/edu/kit/compiler/codegen/PermutationSolver.java
+++ b/src/main/java/edu/kit/compiler/codegen/PermutationSolver.java
@@ -2,20 +2,27 @@ package edu.kit.compiler.codegen;
 
 import lombok.Data;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class PermutationSolver {
-    private Map<Integer, Integer> mapping;
+    private Map<Integer, Deque<Integer>> mapping;
 
     public PermutationSolver() {
         this.mapping = new HashMap<>();
     }
 
     public void addMapping(int input, int target) {
-        mapping.put(input, target);
+        if (mapping.containsKey(input)) {
+            mapping.get(input).push(target);
+        } else {
+            Deque<Integer> vals = new ArrayDeque<>();
+            vals.push(target);
+            mapping.put(input, vals);
+        }
+    }
+
+    public void addMapping(Assignment assignment) {
+        addMapping(assignment.getInput(), assignment.getTarget());
     }
 
     /**
@@ -33,32 +40,63 @@ public class PermutationSolver {
         while (!mapping.isEmpty()) {
             // each iteration handles one "connected component"
             assignOrder.clear();
+
+            int firstInput = -1;
             int currentTarget = -1;
-            for (Map.Entry<Integer, Integer> entry: mapping.entrySet()) {
-                currentTarget = entry.getValue();
-                assignOrder.add(entry.getKey());
+            Deque<Integer> currentVals = null;
+            for (var entry: mapping.entrySet()) {
+                currentVals = entry.getValue();
+                firstInput = entry.getKey();
+                currentTarget = currentVals.pop();
+                assignOrder.add(firstInput);
                 break;
             }
+
+            boolean cycle = false;
             while (mapping.containsKey(currentTarget)) {
-                if (currentTarget == assignOrder.get(0) && assignOrder.size() > 1) {
-                    // handle cycle
-                    assignOrder.add(0, temporary);
-                    currentTarget = temporary;
-                    break;
-                } else if (currentTarget == assignOrder.get(0)) {
-                    // self-assignment
-                    mapping.remove(currentTarget);
-                    assignOrder.clear();
+                if (currentTarget == firstInput) {
+                    if (assignOrder.size() > 1) {
+                        // handle cycle
+                        assignOrder.add(0, temporary);
+                        mapping.put(firstInput, currentVals);
+                        currentTarget = temporary;
+                    } else {
+                        // self-assignment
+                        if (currentVals.isEmpty()) {
+                            mapping.remove(firstInput);
+                        }
+                        assignOrder.clear();
+                    }
+                    cycle = true;
                     break;
                 }
+
+                // if more assignments are remaining for this input,
+                // we propagate them to the target so that they are
+                // processed in another round
+                Deque<Integer> tmp = currentVals;
+                currentVals = mapping.get(currentTarget);
+                mapping.put(currentTarget, tmp);
                 assignOrder.add(currentTarget);
-                currentTarget = mapping.get(currentTarget);
+                currentTarget = currentVals.pop();
             }
+
+            // update mapping for beginning and end if there was no cycle
+            if (!cycle) {
+                mapping.remove(firstInput);
+                if (!currentVals.isEmpty()) {
+                    mapping.put(currentTarget, currentVals);
+                }
+            }
+
+            // output moves and cleanup
             for (int i = assignOrder.size() - 1; i >= 0; i--) {
                 int prev = assignOrder.get(i);
                 result.add(new Assignment(prev, currentTarget));
                 currentTarget = prev;
-                mapping.remove(prev);
+                if (mapping.containsKey(prev) && mapping.get(prev).isEmpty()) {
+                    mapping.remove(prev);
+                }
             }
         }
 

--- a/src/main/java/edu/kit/compiler/codegen/PermutationSolver.java
+++ b/src/main/java/edu/kit/compiler/codegen/PermutationSolver.java
@@ -1,0 +1,84 @@
+package edu.kit.compiler.codegen;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PermutationSolver {
+    private Map<Integer, Integer> mapping;
+
+    public PermutationSolver() {
+        this.mapping = new HashMap<>();
+    }
+
+    public void addMapping(int input, int target) {
+        mapping.put(input, target);
+    }
+
+    /**
+     * Solves the mapping by returning a list of assignments that implements the mapping.
+     * Also resets the state.
+     *
+     * @param temporary register that can be used for spilling, must not be part of the mapping
+     * @return list of assignments
+     */
+    public List<Assignment> solve(int temporary) {
+        assert !mapping.containsKey(temporary);
+
+        List<Assignment> result = new ArrayList<>();
+        List<Integer> assignOrder = new ArrayList<>();
+        while (!mapping.isEmpty()) {
+            // each iteration handles one "connected component"
+            assignOrder.clear();
+            int currentTarget = -1;
+            for (Map.Entry<Integer, Integer> entry: mapping.entrySet()) {
+                currentTarget = entry.getValue();
+                assignOrder.add(entry.getKey());
+                break;
+            }
+            while (mapping.containsKey(currentTarget)) {
+                if (currentTarget == assignOrder.get(0) && assignOrder.size() > 1) {
+                    // handle cycle
+                    assignOrder.add(0, temporary);
+                    currentTarget = temporary;
+                    break;
+                } else if (currentTarget == assignOrder.get(0)) {
+                    // self-assignment
+                    mapping.remove(currentTarget);
+                    assignOrder.clear();
+                    break;
+                }
+                assignOrder.add(currentTarget);
+                currentTarget = mapping.get(currentTarget);
+            }
+            for (int i = assignOrder.size() - 1; i >= 0; i--) {
+                int prev = assignOrder.get(i);
+                result.add(new Assignment(prev, currentTarget));
+                currentTarget = prev;
+                mapping.remove(prev);
+            }
+        }
+
+        assert mapping.isEmpty();
+        return result;
+    }
+
+    @Data
+    public static class Assignment {
+        private int input;
+        private int target;
+
+        public Assignment(int input, int target) {
+            this.input = input;
+            this.target = target;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%d=>%d", input, target);
+        }
+    }
+}

--- a/src/main/java/edu/kit/compiler/codegen/PermutationSolver.java
+++ b/src/main/java/edu/kit/compiler/codegen/PermutationSolver.java
@@ -38,70 +38,95 @@ public class PermutationSolver {
         List<Assignment> result = new ArrayList<>();
         List<Integer> assignOrder = new ArrayList<>();
         while (!mapping.isEmpty()) {
-            // each iteration handles one "connected component"
-            assignOrder.clear();
-
-            int firstInput = -1;
-            int currentTarget = -1;
-            Deque<Integer> currentVals = null;
-            for (var entry: mapping.entrySet()) {
-                currentVals = entry.getValue();
-                firstInput = entry.getKey();
-                currentTarget = currentVals.pop();
-                assignOrder.add(firstInput);
+            int key = -1;
+            for (int k: mapping.keySet()) {
+                key = k;
                 break;
             }
-
-            boolean cycle = false;
-            while (mapping.containsKey(currentTarget)) {
-                if (currentTarget == firstInput) {
-                    if (assignOrder.size() > 1) {
-                        // handle cycle
-                        assignOrder.add(0, temporary);
-                        mapping.put(firstInput, currentVals);
-                        currentTarget = temporary;
-                    } else {
-                        // self-assignment
-                        if (currentVals.isEmpty()) {
-                            mapping.remove(firstInput);
-                        }
-                        assignOrder.clear();
-                    }
-                    cycle = true;
-                    break;
-                }
-
-                // if more assignments are remaining for this input,
-                // we propagate them to the target so that they are
-                // processed in another round
-                Deque<Integer> tmp = currentVals;
-                currentVals = mapping.get(currentTarget);
-                mapping.put(currentTarget, tmp);
-                assignOrder.add(currentTarget);
-                currentTarget = currentVals.pop();
-            }
-
-            // update mapping for beginning and end if there was no cycle
-            if (!cycle) {
-                mapping.remove(firstInput);
-                if (!currentVals.isEmpty()) {
-                    mapping.put(currentTarget, currentVals);
-                }
-            }
-
-            // output moves and cleanup
-            for (int i = assignOrder.size() - 1; i >= 0; i--) {
-                int prev = assignOrder.get(i);
-                result.add(new Assignment(prev, currentTarget));
-                currentTarget = prev;
-                if (mapping.containsKey(prev) && mapping.get(prev).isEmpty()) {
-                    mapping.remove(prev);
-                }
-            }
+            handleForKey(key, assignOrder, result, temporary);
         }
 
         assert mapping.isEmpty();
         return result;
+    }
+
+    /**
+     * Solves the mapping without using a new temporary,
+     * given that there is a known non-cyclic component
+     * (or free register).
+     *
+     * @param first register that is either free or first input for a non-cycle
+     * @return list of assignments
+     */
+    public List<Assignment> solveFromNonCycle(int first) {
+        if (!mapping.containsKey(first)) {
+            return solve(first);
+        }
+
+        List<Assignment> result = new ArrayList<>();
+        List<Integer> assignOrder = new ArrayList<>();
+        handleForKey(first, assignOrder, result, -1);
+
+        List<Assignment> remaining = solve(first);
+        result.addAll(remaining);
+        return result;
+    }
+
+    private void handleForKey(int key, List<Integer> assignOrder, List<Assignment> result, int temporary) {
+        // handles a "path" or "cycle" starting from a specific key
+        assignOrder.clear();
+
+        Deque<Integer> currentVals = mapping.get(key);
+        int firstInput = key;
+        int currentTarget = currentVals.pop();
+        assignOrder.add(firstInput);
+
+        boolean cycle = false;
+        while (mapping.containsKey(currentTarget)) {
+            if (currentTarget == firstInput) {
+                if (assignOrder.size() > 1) {
+                    // handle cycle
+                    assignOrder.add(0, temporary);
+                    mapping.put(firstInput, currentVals);
+                    currentTarget = temporary;
+                } else {
+                    // self-assignment
+                    if (currentVals.isEmpty()) {
+                        mapping.remove(firstInput);
+                    }
+                    assignOrder.clear();
+                }
+                cycle = true;
+                break;
+            }
+
+            // if more assignments are remaining for this input,
+            // we propagate them to the target so that they are
+            // processed in another round
+            Deque<Integer> tmp = currentVals;
+            currentVals = mapping.get(currentTarget);
+            mapping.put(currentTarget, tmp);
+            assignOrder.add(currentTarget);
+            currentTarget = currentVals.pop();
+        }
+
+        // update mapping for beginning and end if there was no cycle
+        if (!cycle) {
+            mapping.remove(firstInput);
+            if (!currentVals.isEmpty()) {
+                mapping.put(currentTarget, currentVals);
+            }
+        }
+
+        // output moves and cleanup
+        for (int i = assignOrder.size() - 1; i >= 0; i--) {
+            int prev = assignOrder.get(i);
+            result.add(new Assignment(prev, currentTarget));
+            currentTarget = prev;
+            if (mapping.containsKey(prev) && mapping.get(prev).isEmpty()) {
+                mapping.remove(prev);
+            }
+        }
     }
 
     @Data

--- a/src/main/java/edu/kit/compiler/codegen/PhiResolver.java
+++ b/src/main/java/edu/kit/compiler/codegen/PhiResolver.java
@@ -1,0 +1,102 @@
+package edu.kit.compiler.codegen;
+
+import edu.kit.compiler.intermediate_lang.Block;
+import edu.kit.compiler.intermediate_lang.Instruction;
+import edu.kit.compiler.intermediate_lang.RegisterSize;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Transforms the output of the instruction selection by replacing the phis
+ * and returning a mapping from block ids to IL blocks.
+ *
+ * Note: the blocks are _not_ in topological order yet and the number of
+ * backrefs is not set.
+ */
+public class PhiResolver {
+    public static Map<Integer, Block> apply(InstructionSelection selection) {
+        Map<Integer, Block> mapping = new HashMap<>();
+        for (var block : selection.getBlocks().getEntries()) {
+            resolvePhisForBlock(selection, mapping, block);
+        }
+
+        translateExistingBlocks(selection, mapping);
+        return mapping;
+    }
+
+    private static void translateExistingBlocks(InstructionSelection selection, Map<Integer, Block> mapping) {
+        for (var block : selection.getBlocks().getEntries()) {
+            Block ilBlock = new Block(block.getBlockId());
+            ilBlock.getInstructions().addAll(block.getInstructions());
+            ilBlock.getInstructions().addAll(block.getExitInstructions());
+
+            assert !mapping.containsKey(ilBlock.getBlockId());
+            mapping.put(ilBlock.getBlockId(), ilBlock);
+        }
+    }
+
+    private static void resolvePhisForBlock(InstructionSelection selection, Map<Integer, Block> mapping,
+                                            BasicBlocks.BlockEntry block) {
+        Map<Integer, PhiAssignments> predMapping = new HashMap<>();
+
+        // for each predecessor block, collect the required phi assignments
+        for (var phiInstruction : block.getPhiInstructions()) {
+            for (var entry : phiInstruction.getEntries()) {
+                BasicBlocks.BlockEntry predBlock = selection.getBlocks().getEntry(entry.getPredBlock());
+                var assignments = predMapping.computeIfAbsent(
+                        predBlock.getBlockId(), k -> new PhiAssignments(predBlock)
+                );
+                assignments.add(entry.getRegister(), phiInstruction.getTargetRegister());
+            }
+        }
+
+        PermutationSolver solver = new PermutationSolver();
+        for (PhiAssignments assignments: predMapping.values()) {
+            List<Instruction> instructions = new ArrayList<>();
+
+            // solve the permutation and add the according move instructions
+            for (PermutationSolver.Assignment ass: assignments.getAssignments()) {
+                solver.addMapping(ass);
+            }
+            int tmpRegister = selection.getMatcher().getNewRegister(RegisterSize.QUAD);
+            for (PermutationSolver.Assignment ass: solver.solve(tmpRegister)) {
+                instructions.add(Instruction.newUnsignedMov(ass.getInput(), ass.getTarget()));
+            }
+
+            ExitCondition condition = assignments.getPred().getExitCondition().get();
+            if (condition.isUnconditional()) {
+                // add instructions to predecessor block
+                assignments.getPred().append(instructions);
+            } else {
+                // add a new block if the edge is critical
+                instructions.add(Instruction.newJmp(
+                        Util.formatJmp("jmp", block.getBlockId()), block.getBlockId())
+                );
+
+                int newBlockId = selection.getBlocks().newBlockId();
+                Block newBlock = new Block(instructions, newBlockId, 0);
+
+                assert !mapping.containsKey(newBlockId);
+                mapping.put(newBlockId, newBlock);
+                condition.replaceBlock(block.getBlockId(), newBlockId);
+            }
+        }
+    }
+
+    /**
+     * Phi assignments that belong to a specific predecessor block.
+     */
+    @Data
+    private static class PhiAssignments {
+        private final BasicBlocks.BlockEntry pred;
+        private final  List<PermutationSolver.Assignment> assignments = new ArrayList<>();
+
+        public void add(int source, int target) {
+            assignments.add(new PermutationSolver.Assignment(source, target));
+        }
+    }
+}

--- a/src/main/java/edu/kit/compiler/codegen/PhiResolver.java
+++ b/src/main/java/edu/kit/compiler/codegen/PhiResolver.java
@@ -30,7 +30,7 @@ public class PhiResolver {
 
     private static void translateExistingBlocks(InstructionSelection selection, Map<Integer, Block> mapping) {
         for (var block : selection.getBlocks().getEntries()) {
-            Block ilBlock = new Block(block.getBlockId());
+            Block ilBlock = new Block(block.getJumpLabel());
             ilBlock.getInstructions().addAll(block.getInstructions());
             ilBlock.getInstructions().addAll(block.getExitInstructions());
 
@@ -48,7 +48,7 @@ public class PhiResolver {
             for (var entry : phiInstruction.getEntries()) {
                 BasicBlocks.BlockEntry predBlock = selection.getBlocks().getEntry(entry.getPredBlock());
                 var assignments = predMapping.computeIfAbsent(
-                        predBlock.getBlockId(), k -> new PhiAssignments(predBlock)
+                        predBlock.getJumpLabel(), k -> new PhiAssignments(predBlock)
                 );
                 assignments.add(entry.getRegister(), phiInstruction.getTargetRegister());
             }
@@ -74,15 +74,15 @@ public class PhiResolver {
             } else {
                 // add a new block if the edge is critical
                 instructions.add(Instruction.newJmp(
-                        Util.formatJmp("jmp", block.getBlockId()), block.getBlockId())
+                        Util.formatJmp("jmp", block.getJumpLabel()), block.getJumpLabel())
                 );
 
-                int newBlockId = selection.getBlocks().newBlockId();
+                int newBlockId = selection.getBlocks().newLabel();
                 Block newBlock = new Block(instructions, newBlockId, 0);
 
                 assert !mapping.containsKey(newBlockId);
                 mapping.put(newBlockId, newBlock);
-                condition.replaceBlock(block.getBlockId(), newBlockId);
+                condition.replaceBlock(block.getJumpLabel(), newBlockId);
             }
         }
     }

--- a/src/main/java/edu/kit/compiler/codegen/PhiResolver.java
+++ b/src/main/java/edu/kit/compiler/codegen/PhiResolver.java
@@ -30,7 +30,7 @@ public class PhiResolver {
 
     private static void translateExistingBlocks(InstructionSelection selection, Map<Integer, Block> mapping) {
         for (var block : selection.getBlocks().getEntries()) {
-            Block ilBlock = new Block(block.getJumpLabel());
+            Block ilBlock = new Block(block.getLabel());
             ilBlock.getInstructions().addAll(block.getInstructions());
             ilBlock.getInstructions().addAll(block.getExitInstructions());
 
@@ -48,7 +48,7 @@ public class PhiResolver {
             for (var entry : phiInstruction.getEntries()) {
                 BasicBlocks.BlockEntry predBlock = selection.getBlocks().getEntry(entry.getPredBlock());
                 var assignments = predMapping.computeIfAbsent(
-                        predBlock.getJumpLabel(), k -> new PhiAssignments(predBlock)
+                        predBlock.getLabel(), k -> new PhiAssignments(predBlock)
                 );
                 assignments.add(entry.getRegister(), phiInstruction.getTargetRegister());
             }
@@ -74,7 +74,7 @@ public class PhiResolver {
             } else {
                 // add a new block if the edge is critical
                 instructions.add(Instruction.newJmp(
-                        Util.formatJmp("jmp", block.getJumpLabel()), block.getJumpLabel())
+                        Util.formatJmp("jmp", block.getLabel()), block.getLabel())
                 );
 
                 int newBlockId = selection.getBlocks().newLabel();
@@ -82,7 +82,7 @@ public class PhiResolver {
 
                 assert !mapping.containsKey(newBlockId);
                 mapping.put(newBlockId, newBlock);
-                condition.replaceBlock(block.getJumpLabel(), newBlockId);
+                condition.replaceBlock(block.getLabel(), newBlockId);
             }
         }
     }

--- a/src/main/java/edu/kit/compiler/codegen/ReversePostfixOrder.java
+++ b/src/main/java/edu/kit/compiler/codegen/ReversePostfixOrder.java
@@ -7,8 +7,17 @@ import lombok.Data;
 import java.util.*;
 
 /**
- * Arranges the given blocks in reverse postfix order and sets
- * the number of backrefs.
+ * Arranges the given blocks and sets the number of backreferences for each block.
+ *
+ * The order that is calculated:
+ *  - is a reverse postfix order (and thus a topological order except for loops)
+ *  - ensures that the blocks of each loop are in contiguous order without holes
+ *
+ *  This is (more or less) the best possible block layout for linear scan register
+ *  allocation. However, the second condition is surprisingly hard to correctly
+ *  calculate in the general case (i.e. with multiple nested loops and complicated
+ *  control flow). Therefore, we need a separate step that analyses the loop depth
+ *  of the blocks.
  */
 public class ReversePostfixOrder {
     private Map<Integer, Block> blocks;

--- a/src/main/java/edu/kit/compiler/codegen/ReversePostfixOrder.java
+++ b/src/main/java/edu/kit/compiler/codegen/ReversePostfixOrder.java
@@ -13,6 +13,7 @@ import java.util.*;
 public class ReversePostfixOrder {
     private Map<Integer, Block> blocks;
     private Set<Integer> visited = new HashSet<>();
+    private Set<Integer> active = new HashSet<>();
 
     private ReversePostfixOrder(Map<Integer, Block> blocks) {
         this.blocks = blocks;
@@ -30,13 +31,16 @@ public class ReversePostfixOrder {
     }
 
     private DFSResult depthFirstSearch(Block block) {
-        if (visited.contains(block.getBlockId())) {
+        if (active.contains(block.getBlockId())) {
             block.addBackRef();
             return new DFSResult(-1, new ArrayList<>(), true);
+        } else if (visited.contains(block.getBlockId())) {
+            return new DFSResult(-1, new ArrayList<>(), false);
         }
 
         assert block.getNumBackReferences() == 0;
         visited.add(block.getBlockId());
+        active.add(block.getBlockId());
         // TODO: remove trivial jumps
 
         List<DFSResult> children = new ArrayList<>();
@@ -74,6 +78,8 @@ public class ReversePostfixOrder {
             instrs.remove(instrs.size() - 1);
         }
         result.add(block);
+
+        active.remove(block.getBlockId());
         return new DFSResult(block.getBlockId(), result, alwaysEndsInBackref);
     }
 

--- a/src/main/java/edu/kit/compiler/codegen/ReversePostfixOrder.java
+++ b/src/main/java/edu/kit/compiler/codegen/ReversePostfixOrder.java
@@ -1,0 +1,49 @@
+package edu.kit.compiler.codegen;
+
+import edu.kit.compiler.intermediate_lang.Block;
+import edu.kit.compiler.intermediate_lang.Instruction;
+
+import java.util.*;
+
+/**
+ * Arranges the given blocks in reverse postfix order and sets
+ * the number of backrefs.
+ */
+public class ReversePostfixOrder {
+    private Map<Integer, Block> blocks;
+    private Set<Integer> visited = new HashSet<>();
+    private List<Block> result = new ArrayList<>();
+
+    private ReversePostfixOrder(Map<Integer, Block> blocks) {
+        this.blocks = blocks;
+    }
+
+    public static List<Block> apply(Map<Integer, Block> blocks, int startBlock) {
+        ReversePostfixOrder instance = new ReversePostfixOrder(blocks);
+        instance.depthFirstSearch(blocks.get(startBlock));
+
+        List<Block> reversed = new ArrayList<>();
+        for (int i = instance.result.size() - 1; i >= 0; i--) {
+            reversed.add(instance.result.get(i));
+        }
+        return reversed;
+    }
+
+    private void depthFirstSearch(Block block) {
+        if (visited.contains(block.getBlockId())) {
+            block.addBackRef();
+            return;
+        }
+
+        assert block.getNumBackReferences() == 0;
+        visited.add(block.getBlockId());
+        // TODO: remove trivial jumps
+        for (Instruction instr: block.getInstructions()) {
+            if (instr.getJumpTarget().isPresent()) {
+                int jmpTarget = instr.getJumpTarget().get();
+                depthFirstSearch(blocks.get(jmpTarget));
+            }
+        }
+        result.add(block);
+    }
+}

--- a/src/main/java/edu/kit/compiler/intermediate_lang/Block.java
+++ b/src/main/java/edu/kit/compiler/intermediate_lang/Block.java
@@ -3,6 +3,7 @@ package edu.kit.compiler.intermediate_lang;
 import lombok.Data;
 import lombok.Getter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Data
@@ -21,11 +22,24 @@ public class Block {
      * i.e. where the jump appears after this block.
      */
     @Getter
-    private final int numBackReferences;
+    private int numBackReferences;
 
     public Block(List<Instruction> instructions, int blockId, int numBackReferences) {
         this.instructions = instructions;
         this.blockId = blockId;
         this.numBackReferences = numBackReferences;
+    }
+
+    public Block(int blockId) {
+        this(new ArrayList<>(), blockId, 0);
+    }
+
+    public void addBackRef() {
+        numBackReferences++;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("(.L%d: %s)", blockId, instructions.toString());
     }
 }

--- a/src/main/java/edu/kit/compiler/intermediate_lang/Block.java
+++ b/src/main/java/edu/kit/compiler/intermediate_lang/Block.java
@@ -25,7 +25,7 @@ public class Block {
     private int numBackReferences;
 
     public Block(List<Instruction> instructions, int blockId, int numBackReferences) {
-        this.instructions = instructions;
+        this.instructions = new ArrayList<>(instructions);
         this.blockId = blockId;
         this.numBackReferences = numBackReferences;
     }

--- a/src/test/java/edu/kit/compiler/codegen/PermutationSolverTest.java
+++ b/src/test/java/edu/kit/compiler/codegen/PermutationSolverTest.java
@@ -1,0 +1,61 @@
+package edu.kit.compiler.codegen;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PermutationSolverTest {
+    @Test
+    public void testSelfAssign() {
+        PermutationSolver solver = new PermutationSolver();
+        solver.addMapping(0, 0);
+        solver.addMapping(1, 1);
+        for (var ass: solver.solve(2)) {
+            assert false;
+        }
+    }
+
+    @RepeatedTest(100)
+    public void testRandomized() {
+        PermutationSolver solver = new PermutationSolver();
+        int size = (int)(10 * Math.random());
+        int inputRange = size + (int)(3 * Math.random());
+        List<Integer> input = new ArrayList<>();
+        List<Integer> targets = new ArrayList<>();
+
+        for (int i = 0; i < size; i++) {
+            int next;
+            do {
+                next = (int) (inputRange * Math.random());
+            } while (input.contains(next));
+            input.add(next);
+        }
+
+        for (int i = 0; i < size; i++) {
+            int next;
+            do {
+                next = (int)(size * Math.random());
+            } while (targets.contains(next));
+            targets.add(next);
+        }
+
+        for (int i = 0; i < size; i++) {
+            solver.addMapping(input.get(i), targets.get(i));
+        }
+
+        int[] data = new int[inputRange + 1];
+        for (int i = 0; i <= inputRange; i++) {
+            data[i] = i;
+        }
+        for (var ass: solver.solve(inputRange)) {
+            data[ass.getTarget()] = data[ass.getInput()];
+        }
+        for (int i = 0; i < size; i++) {
+            assertEquals(input.get(i), data[targets.get(i)]);
+        }
+    }
+}

--- a/src/test/java/edu/kit/compiler/codegen/PermutationSolverTest.java
+++ b/src/test/java/edu/kit/compiler/codegen/PermutationSolverTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -54,6 +55,13 @@ public class PermutationSolverTest {
         checkForData(input, targets, 9);
     }
 
+    @Test
+    public void testBadInput() {
+        List<Integer> input = List.of(3, 3, 3, 0, 0, 3, 2, 3, 4, 1, 1);
+        List<Integer> targets = List.of(10, 4, 11, 6, 1, 8, 3, 2, 5, 9, 7);
+        checkForData(input, targets, 12);
+    }
+
     @RepeatedTest(100)
     public void testRandomized() {
         int size = (int)(10 * Math.random());
@@ -93,15 +101,25 @@ public class PermutationSolverTest {
         for (int i = 0; i < size; i++) {
             int next;
             do {
-                next = (int)(size * Math.random());
+                next = (int)((size + 1) * Math.random());
             } while (targets.contains(next));
             targets.add(next);
         }
 
-        checkForData(input, targets, size);
+        checkForData(input, targets, size + 2);
+
+        for (int first: input) {
+            if (!targets.contains(first)) {
+                checkForData(input, targets, size, Optional.of(first));
+            }
+        }
     }
 
     private void checkForData(List<Integer> input, List<Integer> targets, int maxInput) {
+        checkForData(input, targets, maxInput, Optional.empty());
+    }
+
+    private void checkForData(List<Integer> input, List<Integer> targets, int maxInput, Optional<Integer> first) {
         assertEquals(input.size(), targets.size());
         PermutationSolver solver = new PermutationSolver();
 
@@ -113,7 +131,7 @@ public class PermutationSolverTest {
         for (int i = 0; i <= maxInput; i++) {
             data[i] = i;
         }
-        for (var ass: solver.solve(maxInput)) {
+        for (var ass: first.isPresent() ? solver.solveFromNonCycle(first.get()) : solver.solve(maxInput)) {
             data[ass.getTarget()] = data[ass.getInput()];
         }
         for (int i = 0; i < input.size(); i++) {

--- a/src/test/java/edu/kit/compiler/codegen/PermutationSolverTest.java
+++ b/src/test/java/edu/kit/compiler/codegen/PermutationSolverTest.java
@@ -19,9 +19,43 @@ public class PermutationSolverTest {
         }
     }
 
+    @Test
+    public void testSwap() {
+        List<Integer> input = List.of(0, 1);
+        List<Integer> targets = List.of(1, 0);
+        checkForData(input, targets, 2);
+    }
+
+    @Test
+    public void testCycle() {
+        List<Integer> input = List.of(0, 1, 2);
+        List<Integer> targets = List.of(2, 0, 1);
+        checkForData(input, targets, 3);
+    }
+
+    @Test
+    public void testTree() {
+        List<Integer> input = List.of(0, 1, 0, 1);
+        List<Integer> targets = List.of(1, 3, 2, 4);
+        checkForData(input, targets, 5);
+    }
+
+    @Test
+    public void testCycleWithLeafs1() {
+        List<Integer> input = List.of(0, 1, 2, 0, 1, 2, 0, 1, 2);
+        List<Integer> targets = List.of(1, 2, 0, 3, 4, 5, 6, 7, 8);
+        checkForData(input, targets, 9);
+    }
+
+    @Test
+    public void testCycleWithLeafs2() {
+        List<Integer> input = List.of(0, 1, 2, 0, 1, 2, 0, 1, 2);
+        List<Integer> targets = List.of(3, 4, 5, 6, 7, 8, 1, 2, 0);
+        checkForData(input, targets, 9);
+    }
+
     @RepeatedTest(100)
     public void testRandomized() {
-        PermutationSolver solver = new PermutationSolver();
         int size = (int)(10 * Math.random());
         int inputRange = size + (int)(3 * Math.random());
         List<Integer> input = new ArrayList<>();
@@ -43,19 +77,47 @@ public class PermutationSolverTest {
             targets.add(next);
         }
 
+        checkForData(input, targets, inputRange);
+    }
+
+    @RepeatedTest(100)
+    public void testRandomizedOverlappingInput() {
+        int size = (int)(10 * Math.random()) + 2;
+        List<Integer> input = new ArrayList<>();
+        List<Integer> targets = new ArrayList<>();
+
         for (int i = 0; i < size; i++) {
+            input.add((int)(size * Math.random()) / 2);
+        }
+
+        for (int i = 0; i < size; i++) {
+            int next;
+            do {
+                next = (int)(size * Math.random());
+            } while (targets.contains(next));
+            targets.add(next);
+        }
+
+        checkForData(input, targets, size);
+    }
+
+    private void checkForData(List<Integer> input, List<Integer> targets, int maxInput) {
+        assertEquals(input.size(), targets.size());
+        PermutationSolver solver = new PermutationSolver();
+
+        for (int i = 0; i < input.size(); i++) {
             solver.addMapping(input.get(i), targets.get(i));
         }
 
-        int[] data = new int[inputRange + 1];
-        for (int i = 0; i <= inputRange; i++) {
+        int[] data = new int[maxInput + 1];
+        for (int i = 0; i <= maxInput; i++) {
             data[i] = i;
         }
-        for (var ass: solver.solve(inputRange)) {
+        for (var ass: solver.solve(maxInput)) {
             data[ass.getTarget()] = data[ass.getInput()];
         }
-        for (int i = 0; i < size; i++) {
-            assertEquals(input.get(i), data[targets.get(i)]);
+        for (int i = 0; i < input.size(); i++) {
+            assertEquals(input.get(i), data[targets.get(i)], "index=" + i);
         }
     }
 }

--- a/src/test/java/edu/kit/compiler/codegen/ReversePostfixOrderTest.java
+++ b/src/test/java/edu/kit/compiler/codegen/ReversePostfixOrderTest.java
@@ -1,0 +1,164 @@
+package edu.kit.compiler.codegen;
+
+import edu.kit.compiler.intermediate_lang.Block;
+import edu.kit.compiler.intermediate_lang.Instruction;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ReversePostfixOrderTest {
+    @Test
+    public void testIfElse() {
+        Block ifBlock = new Block(List.of(
+                Instruction.newJmp("", 1), Instruction.newJmp("", 2)
+        ), 0, 0);
+        Block thenBlock = new Block(List.of(
+                Instruction.newJmp("", 3)
+        ), 1, 0);
+        Block elseBlock = new Block(List.of(
+                Instruction.newJmp("", 3)
+        ), 2, 0);
+        Block finalBlock = new Block(List.of(
+                Instruction.newRet(Optional.empty())
+        ), 3, 0);
+
+        var blocks = List.of(elseBlock, ifBlock, finalBlock, thenBlock);
+        Map<Integer, Block> map = new HashMap<>();
+        for (Block b: blocks) {
+            map.put(b.getBlockId(), b);
+        }
+        var result = ReversePostfixOrder.apply(map, 0);
+        assertEquals(List.of(0, 2, 1, 3),
+                result.stream().map(Block::getBlockId).collect(Collectors.toList()));
+        assertEquals(List.of(0, 0, 0, 0),
+                result.stream().map(Block::getNumBackReferences).collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testSimpleLoop() {
+        Block start = new Block(List.of(
+                Instruction.newJmp("", 1)
+        ), 0, 0);
+        Block header = new Block(List.of(
+                Instruction.newJmp("", 2), Instruction.newJmp("", 3)
+        ), 1, 0);
+        Block body = new Block(List.of(
+                Instruction.newJmp("", 1)
+        ), 2, 0);
+        Block finalBlock = new Block(List.of(
+                Instruction.newRet(Optional.empty())
+        ), 3, 0);
+
+        var blocks = List.of(start, finalBlock, body, header);
+        Map<Integer, Block> map = new HashMap<>();
+        for (Block b: blocks) {
+            map.put(b.getBlockId(), b);
+        }
+        var result = ReversePostfixOrder.apply(map, 0);
+        assertEquals(List.of(0, 1, 2, 3),
+                result.stream().map(Block::getBlockId).collect(Collectors.toList()));
+        assertEquals(List.of(0, 1, 0, 0),
+                result.stream().map(Block::getNumBackReferences).collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testComplexLoop() {
+        Block start = new Block(List.of(
+                Instruction.newJmp("", 1)
+        ), 0, 0);
+        Block headerIf = new Block(List.of(
+                Instruction.newJmp("", 2), Instruction.newJmp("", 3)
+        ), 1, 0);
+        Block headerThen = new Block(List.of(
+                Instruction.newJmp("", 4)
+        ), 2, 0);
+        Block headerElse = new Block(List.of(
+                Instruction.newJmp("", 4)
+        ), 3, 0);
+        Block headerFinal = new Block(List.of(
+                Instruction.newJmp("", 5), Instruction.newJmp("", 8)
+        ), 4, 0);
+        Block bodyIf = new Block(List.of(
+                Instruction.newJmp("", 6), Instruction.newJmp("", 7)
+        ), 5, 0);
+        Block bodyThen = new Block(List.of(
+                Instruction.newJmp("", 1)
+        ), 6, 0);
+        Block bodyElse = new Block(List.of(
+                Instruction.newJmp("", 1)
+        ), 7, 0);
+        Block finalBlock = new Block(List.of(
+                Instruction.newRet(Optional.empty())
+        ), 8, 0);
+
+        var blocks = List.of(start, headerIf, headerThen, headerElse, headerFinal,
+                bodyIf, bodyThen, bodyElse, finalBlock);
+        Map<Integer, Block> map = new HashMap<>();
+        for (Block b: blocks) {
+            map.put(b.getBlockId(), b);
+        }
+        var result = ReversePostfixOrder.apply(map, 0);
+        assertEquals(List.of(0, 1, 3, 2, 4, 5, 7, 6, 8),
+                result.stream().map(Block::getBlockId).collect(Collectors.toList()));
+        assertEquals(List.of(0, 2, 0, 0, 0, 0, 0, 0, 0),
+                result.stream().map(Block::getNumBackReferences).collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testNestedComplexLoopWithRet() {
+        Block start = new Block(List.of(
+                Instruction.newJmp("", 1)
+        ), 0, 0);
+        Block headerIf = new Block(List.of(
+                Instruction.newJmp("", 2), Instruction.newJmp("", 3)
+        ), 1, 0);
+        Block headerThen = new Block(List.of(
+                Instruction.newJmp("", 4)
+        ), 2, 0);
+        Block headerElse = new Block(List.of(
+                Instruction.newJmp("", 4)
+        ), 3, 0);
+        Block headerFinal = new Block(List.of(
+                Instruction.newJmp("", 5), Instruction.newJmp("", 10)
+        ), 4, 0);
+
+        Block nestedHeader = new Block(List.of(
+                Instruction.newJmp("", 6), Instruction.newJmp("", 9)
+        ), 5, 0);
+        Block nestedBodyIf = new Block(List.of(
+                Instruction.newJmp("", 7), Instruction.newJmp("", 8)
+        ), 6, 0);
+        Block nestedBodyThen = new Block(List.of(
+                Instruction.newRet(Optional.empty())
+        ), 7, 0);
+        Block nestedBodyElse = new Block(List.of(
+                Instruction.newJmp("", 5)
+        ), 8, 0);
+        Block nestedExit = new Block(List.of(
+                Instruction.newJmp("", 1)
+        ), 9, 0);
+
+
+        Block finalBlock = new Block(List.of(
+                Instruction.newRet(Optional.empty())
+        ), 10, 0);
+
+        var blocks = List.of(start, headerIf, headerThen, headerElse, headerFinal,
+                nestedHeader, nestedBodyIf, nestedBodyThen, nestedBodyElse, nestedExit, finalBlock);
+        Map<Integer, Block> map = new HashMap<>();
+        for (Block b: blocks) {
+            map.put(b.getBlockId(), b);
+        }
+        var result = ReversePostfixOrder.apply(map, 0);
+        assertEquals(List.of(0, 1, 3, 2, 4, 5, 6, 8, 7, 9, 10),
+                result.stream().map(Block::getBlockId).collect(Collectors.toList()));
+        assertEquals(List.of(0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0),
+                result.stream().map(Block::getNumBackReferences).collect(Collectors.toList()));
+    }
+}


### PR DESCRIPTION
Currently, the phi resolver interacts with the instruction selection in the following ways:

1. using the state of the instruction selection to create new virtual registers
2. using the state of the instruction selection to create new block ids
3. appending move instructions to some blocks
4. altering exit conditions when a new block is introduced

1 and 2 are probably unavoidable, 3 could also be done within the `PhiResolver` instead. However, while 4 could be done separately, it would be rather ugly to do so, as the `PhiResolver` would need to duplicate the exit condition mechanism of the instruction selection somehow.

Also, the block ids are now serialized.