### PR TITLE
Change detailed type analysis to use `ErrorHandler`

### DIFF
--- a/src/main/java/edu/kit/compiler/JavaEasyCompiler.java
+++ b/src/main/java/edu/kit/compiler/JavaEasyCompiler.java
@@ -311,7 +311,7 @@ public class JavaEasyCompiler {
         ast.accept(gatheringVisitor);
         // name and type analysis
         DetailedNameTypeAstVisitor nameTypeVisitor = new DetailedNameTypeAstVisitor(
-            namespaceMapper, stringTable
+            namespaceMapper, stringTable, errorHandler
         );
         ast.accept(nameTypeVisitor);
         // remaining semantic checks

--- a/src/main/java/edu/kit/compiler/semantic/Reference.java
+++ b/src/main/java/edu/kit/compiler/semantic/Reference.java
@@ -10,4 +10,9 @@ public interface Reference {
      */
     Definition getDefinition();
 
+    /**
+     * Set the definition of this reference.
+     */
+    void setDefinition(Definition definition);
+
 }

--- a/src/test/java/edu/kit/compiler/optimizations/ConstantOptimizationTest.java
+++ b/src/test/java/edu/kit/compiler/optimizations/ConstantOptimizationTest.java
@@ -63,7 +63,7 @@ public class ConstantOptimizationTest {
         );
         program.accept(gatheringVisitor);
         DetailedNameTypeAstVisitor nameTypeVisitor = new DetailedNameTypeAstVisitor(
-            namespaceMapper, stringTable
+            namespaceMapper, stringTable, errorHandler
         );
         program.accept(nameTypeVisitor);
 

--- a/src/test/java/edu/kit/compiler/semantic/DetailedNameTypeAstVisitorCorrectlyTypedTest.java
+++ b/src/test/java/edu/kit/compiler/semantic/DetailedNameTypeAstVisitorCorrectlyTypedTest.java
@@ -12,6 +12,7 @@ import edu.kit.compiler.data.ast_nodes.MethodNode.MethodNodeParameter;
 import edu.kit.compiler.data.ast_nodes.MethodNode.StaticMethodNode;
 import edu.kit.compiler.data.ast_nodes.StatementNode.*;
 import edu.kit.compiler.lexer.StringTable;
+import edu.kit.compiler.logger.Logger;
 import edu.kit.compiler.semantic.NamespaceMapper.ClassNamespace;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +43,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testField_PredefinedType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ClassNodeField field;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(
@@ -52,7 +54,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(field.isHasError());
     }
 
@@ -60,7 +64,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testField_KnownReferenceType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ClassNodeField field;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(
@@ -69,7 +74,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(field.isHasError());
     }
 
@@ -77,7 +84,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testField_UnknownReferenceType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ClassNodeField field;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(
@@ -86,7 +94,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(field.isHasError());
     }
 
@@ -94,7 +104,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testField_Void() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ClassNodeField field;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(
@@ -103,7 +114,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(field.isHasError());
     }
 
@@ -111,7 +124,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testMethod_Result_PredefinedType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         DynamicMethodNode method;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -122,7 +136,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(method.isHasError());
     }
 
@@ -130,7 +146,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testMethod_Result_KnownReferenceType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         DynamicMethodNode method;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -141,7 +158,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(method.isHasError());
     }
 
@@ -149,7 +168,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testMethod_Result_UnknownReferenceType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         DynamicMethodNode method;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -160,7 +180,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(method.isHasError());
     }
 
@@ -168,7 +190,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testMethod_Result_Void() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         DynamicMethodNode method;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -179,7 +202,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(method.isHasError());
     }
 
@@ -187,7 +212,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testMethod_Parameter_PredefinedType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         MethodNodeParameter parameter;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -200,7 +226,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(parameter.isHasError());
     }
 
@@ -208,7 +236,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testMethod_Parameter_KnownReferenceType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         MethodNodeParameter parameter;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -221,7 +250,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(parameter.isHasError());
     }
 
@@ -229,7 +260,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testMethod_Parameter_UnknownReferenceType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         MethodNodeParameter parameter;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -242,7 +274,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(parameter.isHasError());
     }
 
@@ -250,7 +284,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testMethod_Parameter_Void() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         MethodNodeParameter parameter;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -263,7 +298,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(parameter.isHasError());
     }
 
@@ -271,7 +308,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testLocalVariableStatement_PredefinedType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         LocalVariableDeclarationStatementNode localVariable;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -284,7 +322,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(localVariable.isHasError());
     }
 
@@ -292,7 +332,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testLocalVariableStatement_KnownReferenceType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         LocalVariableDeclarationStatementNode localVariable;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -305,7 +346,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(localVariable.isHasError());
     }
 
@@ -313,7 +356,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testLocalVariableStatement_UnknownReferenceType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         LocalVariableDeclarationStatementNode localVariable;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -326,7 +370,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(localVariable.isHasError());
     }
 
@@ -334,7 +380,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testLocalVariableStatement_Void() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         LocalVariableDeclarationStatementNode localVariable;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -347,7 +394,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(localVariable.isHasError());
     }
 
@@ -355,7 +404,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testLocalVariableStatement_ValidExpression() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         LocalVariableDeclarationStatementNode localVariable;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -370,7 +420,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(localVariable.isHasError());
     }
 
@@ -378,7 +430,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testLocalVariableStatement_InvalidExpression() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         LocalVariableDeclarationStatementNode localVariable;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -393,7 +446,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(localVariable.isHasError());
     }
 
@@ -401,7 +456,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testIfStatementIsCorrectlyType_Boolean() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         IfStatementNode ifStatement;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -417,7 +473,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(ifStatement.isHasError());
     }
 
@@ -425,7 +483,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testIfStatementIsCorrectlyType_NonBoolean() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         IfStatementNode ifStatement;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -441,7 +500,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(ifStatement.isHasError());
     }
 
@@ -449,7 +510,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testWhileStatementIsCorrectlyType_Boolean() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         WhileStatementNode whileStatement;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -465,7 +527,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(whileStatement.isHasError());
     }
 
@@ -473,7 +537,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testWhileStatementIsCorrectlyType_NonBoolean() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         WhileStatementNode whileStatement;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -489,7 +554,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(whileStatement.isHasError());
     }
 
@@ -497,7 +564,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testReturnStatement_ExpectedVoid_Void() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ReturnStatementNode returnStatement;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -510,7 +578,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(returnStatement.isHasError());
     }
 
@@ -518,7 +588,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testReturnStatement_ExpectedVoid_NonVoid() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ReturnStatementNode returnStatement;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -533,7 +604,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(returnStatement.isHasError());
     }
 
@@ -541,7 +614,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testReturnStatement_ExpectedValue_Void() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ReturnStatementNode returnStatement;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -554,7 +628,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(returnStatement.isHasError());
     }
 
@@ -562,7 +638,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testReturnStatement_ExpectedValue_MatchingValue() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ReturnStatementNode returnStatement;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -577,7 +654,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(returnStatement.isHasError());
     }
 
@@ -585,7 +664,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testReturnStatement_ExpectedValue_NonMatchingValue() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ReturnStatementNode returnStatement;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -600,7 +680,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(returnStatement.isHasError());
     }
 
@@ -608,7 +690,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testBinaryExpression_ArgumentsMatchOperator() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         BinaryExpressionNode binaryExpression;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -626,7 +709,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(binaryExpression.isHasError());
     }
 
@@ -634,7 +719,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testBinaryExpression_LeftArgumentDoesNotMatchOperator() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         BinaryExpressionNode binaryExpression;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -652,7 +738,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(binaryExpression.isHasError());
     }
 
@@ -660,7 +748,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testBinaryExpression_RightArgumentDoesNotMatchOperator() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         BinaryExpressionNode binaryExpression;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -678,7 +767,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(binaryExpression.isHasError());
     }
 
@@ -686,7 +777,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testBinaryExpression_BothArgumentsDoNotMatchOperator() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         BinaryExpressionNode binaryExpression;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -704,7 +796,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(binaryExpression.isHasError());
     }
 
@@ -712,7 +806,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testBinaryExpression_VariableTypedArgsMatchOperator() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         BinaryExpressionNode binaryExpression;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -731,7 +826,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(binaryExpression.isHasError());
     }
 
@@ -739,7 +836,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testBinaryExpression_VariableTypedArgsDoNotMatchOperator() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         BinaryExpressionNode binaryExpression;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -758,7 +856,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(binaryExpression.isHasError());
     }
 
@@ -766,7 +866,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testBinaryExpression_VariableTypedArgsMatchOperatorWithAny() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         BinaryExpressionNode binaryExpression;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -785,7 +886,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(binaryExpression.isHasError());
     }
 
@@ -793,7 +896,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testBinaryExpression_VariableTypedArgsMatchOperatorWithAnyAndPrimitiveType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         BinaryExpressionNode binaryExpression;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -812,7 +916,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(binaryExpression.isHasError());
     }
 
@@ -820,7 +926,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testUnaryExpression_ArgumentMatchesOperator() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         UnaryExpressionNode unaryExpression;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -837,7 +944,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(unaryExpression.isHasError());
     }
 
@@ -845,7 +954,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testUnaryExpression_ArgumentDoesNotMatchOperator() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         UnaryExpressionNode unaryExpression;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -862,7 +972,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(unaryExpression.isHasError());
     }
 
@@ -870,7 +982,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testMethodInvocation_UnknownMethod() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         MethodInvocationExpressionNode methodInvocation;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -885,7 +998,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(methodInvocation.isHasError());
     }
 
@@ -893,7 +1008,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testMethodInvocation_NoObject_StaticMethod() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         MethodInvocationExpressionNode methodInvocation;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(
@@ -908,7 +1024,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(methodInvocation.isHasError());
     }
 
@@ -916,7 +1034,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testMethodInvocation_NoObject_NoArgs() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         MethodInvocationExpressionNode methodInvocation;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -931,7 +1050,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(methodInvocation.isHasError());
     }
 
@@ -939,7 +1060,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testMethodInvocation_NoObject_DifferentNumberOfArgs() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         MethodInvocationExpressionNode methodInvocation;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -959,7 +1081,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(methodInvocation.isHasError());
     }
 
@@ -967,7 +1091,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testMethodInvocation_NoObject_WrongArgumentType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         MethodInvocationExpressionNode methodInvocation;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -988,7 +1113,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(methodInvocation.isHasError());
     }
 
@@ -996,7 +1123,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testMethodInvocation_NoObject_CorrectArgs() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         MethodInvocationExpressionNode methodInvocation;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -1017,7 +1145,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(methodInvocation.isHasError());
     }
 
@@ -1025,7 +1155,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testMethodInvocation_WithObject_PredefinedType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         MethodInvocationExpressionNode methodInvocation;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -1043,7 +1174,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(methodInvocation.isHasError());
     }
 
@@ -1051,7 +1184,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testMethodInvocation_WithObject_UnknownMethod() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         MethodInvocationExpressionNode methodInvocation;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -1069,7 +1203,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(methodInvocation.isHasError());
     }
 
@@ -1077,7 +1213,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testMethodInvocation_WithObject_KnownMethod() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         MethodInvocationExpressionNode methodInvocation;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -1095,7 +1232,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(methodInvocation.isHasError());
     }
 
@@ -1103,7 +1242,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testFieldAccess_PredefinedDataType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         FieldAccessExpressionNode fieldAccess;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -1120,7 +1260,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(fieldAccess.isHasError());
     }
 
@@ -1128,7 +1270,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testFieldAccess_UnknownField() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         FieldAccessExpressionNode fieldAccess;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(
@@ -1148,7 +1291,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(fieldAccess.isHasError());
     }
 
@@ -1156,7 +1301,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testFieldAccess_KnownField() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         FieldAccessExpressionNode fieldAccess;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(
@@ -1176,7 +1322,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(fieldAccess.isHasError());
     }
 
@@ -1184,7 +1332,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testArrayAccess_NoArrayType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ArrayAccessExpressionNode arrayAccess;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -1203,7 +1352,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(arrayAccess.isHasError());
     }
 
@@ -1211,7 +1362,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testArrayAccess_IndexIsNoInteger() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ArrayAccessExpressionNode arrayAccess;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -1230,7 +1382,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(arrayAccess.isHasError());
     }
 
@@ -1238,7 +1392,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testArrayAccess_Correct() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ArrayAccessExpressionNode arrayAccess;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -1257,7 +1412,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(arrayAccess.isHasError());
     }
 
@@ -1265,7 +1422,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testNewObjectExpression_UnknownReferenceType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         NewObjectExpressionNode newObject;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -1280,7 +1438,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(newObject.isHasError());
     }
 
@@ -1288,7 +1448,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testNewObjectExpression_KnownReferenceType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         NewObjectExpressionNode newObject;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -1303,7 +1464,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(newObject.isHasError());
     }
 
@@ -1311,7 +1474,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testNewArrayExpression_Void() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         NewArrayExpressionNode newArray;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -1328,7 +1492,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(newArray.isHasError());
     }
 
@@ -1336,7 +1502,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testNewArrayExpression_PredefinedDataType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         NewArrayExpressionNode newArray;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -1353,7 +1520,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(newArray.isHasError());
     }
 
@@ -1361,7 +1530,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testNewArrayExpression_UnknownReferenceType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         NewArrayExpressionNode newArray;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -1378,7 +1548,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(newArray.isHasError());
     }
 
@@ -1386,7 +1558,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testNewArrayExpression_KnownReferenceType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         NewArrayExpressionNode newArray;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -1403,7 +1576,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(newArray.isHasError());
     }
 
@@ -1411,7 +1586,8 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
     public void testNewArrayExpression_LengthIsNoInteger() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         NewArrayExpressionNode newArray;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -1428,7 +1604,9 @@ public class DetailedNameTypeAstVisitorCorrectlyTypedTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(newArray.isHasError());
     }
 

--- a/src/test/java/edu/kit/compiler/semantic/DetailedNameTypeAstVisitorResultTypeTest.java
+++ b/src/test/java/edu/kit/compiler/semantic/DetailedNameTypeAstVisitorResultTypeTest.java
@@ -13,6 +13,7 @@ import edu.kit.compiler.data.ast_nodes.StatementNode.BlockStatementNode;
 import edu.kit.compiler.data.ast_nodes.StatementNode.ExpressionStatementNode;
 import edu.kit.compiler.data.ast_nodes.StatementNode.LocalVariableDeclarationStatementNode;
 import edu.kit.compiler.lexer.StringTable;
+import edu.kit.compiler.logger.Logger;
 import edu.kit.compiler.semantic.NamespaceMapper.ClassNamespace;
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +45,8 @@ public class DetailedNameTypeAstVisitorResultTypeTest {
     public void testBinaryExpression_FixedType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         BinaryExpressionNode binaryExpression;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -72,7 +74,8 @@ public class DetailedNameTypeAstVisitorResultTypeTest {
     public void testBinaryExpression_VariableType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         BinaryExpressionNode binaryExpression;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -101,7 +104,8 @@ public class DetailedNameTypeAstVisitorResultTypeTest {
     public void testBinaryExpression_VariableTypeWithAny() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         BinaryExpressionNode binaryExpression;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -130,7 +134,8 @@ public class DetailedNameTypeAstVisitorResultTypeTest {
     public void testUnaryExpression() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         UnaryExpressionNode unaryExpression;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -157,7 +162,8 @@ public class DetailedNameTypeAstVisitorResultTypeTest {
     public void testMethodInvocation_Void() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         MethodInvocationExpressionNode methodInvocation;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -182,7 +188,8 @@ public class DetailedNameTypeAstVisitorResultTypeTest {
     public void testMethodInvocation() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         MethodInvocationExpressionNode methodInvocation;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -207,7 +214,8 @@ public class DetailedNameTypeAstVisitorResultTypeTest {
     public void testFieldAccess() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         FieldAccessExpressionNode fieldAccess;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(
@@ -237,7 +245,8 @@ public class DetailedNameTypeAstVisitorResultTypeTest {
     public void testArrayAccess_SingleDimension() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ArrayAccessExpressionNode arrayAccess;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -266,7 +275,8 @@ public class DetailedNameTypeAstVisitorResultTypeTest {
     public void testArrayAccess_MultipleDimensions() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ArrayAccessExpressionNode arrayAccess;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -295,7 +305,8 @@ public class DetailedNameTypeAstVisitorResultTypeTest {
     public void testIdentifier() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         IdentifierExpressionNode identifier;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -321,7 +332,8 @@ public class DetailedNameTypeAstVisitorResultTypeTest {
     public void testThis() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ThisExpressionNode _this;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -347,7 +359,8 @@ public class DetailedNameTypeAstVisitorResultTypeTest {
     public void testValue_False() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ValueExpressionNode value;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -372,7 +385,8 @@ public class DetailedNameTypeAstVisitorResultTypeTest {
     public void testValue_True() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ValueExpressionNode value;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -397,7 +411,8 @@ public class DetailedNameTypeAstVisitorResultTypeTest {
     public void testValue_Integer() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ValueExpressionNode value;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -422,7 +437,8 @@ public class DetailedNameTypeAstVisitorResultTypeTest {
     public void testValue_Null() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ValueExpressionNode value;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -447,7 +463,8 @@ public class DetailedNameTypeAstVisitorResultTypeTest {
     public void testNewObject() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         NewObjectExpressionNode newObject;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -472,7 +489,8 @@ public class DetailedNameTypeAstVisitorResultTypeTest {
     public void testNewArray_SingleDimension() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         NewArrayExpressionNode newArray;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -499,7 +517,8 @@ public class DetailedNameTypeAstVisitorResultTypeTest {
     public void testNewArray_MultipleDimensions() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         NewArrayExpressionNode newArray;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(

--- a/src/test/java/edu/kit/compiler/semantic/DetailedNameTypeAstVisitorSystemTest.java
+++ b/src/test/java/edu/kit/compiler/semantic/DetailedNameTypeAstVisitorSystemTest.java
@@ -11,6 +11,7 @@ import edu.kit.compiler.data.ast_nodes.MethodNode.*;
 import edu.kit.compiler.data.ast_nodes.ProgramNode;
 import edu.kit.compiler.data.ast_nodes.StatementNode.*;
 import edu.kit.compiler.lexer.StringTable;
+import edu.kit.compiler.logger.Logger;
 import edu.kit.compiler.semantic.NamespaceMapper.ClassNamespace;
 import org.junit.jupiter.api.Test;
 
@@ -41,6 +42,7 @@ public class DetailedNameTypeAstVisitorSystemTest {
     public void testSystemCall_Correct() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
 
         ClassNode _class;
         MethodInvocationExpressionNode methodInvocation;
@@ -64,9 +66,10 @@ public class DetailedNameTypeAstVisitorSystemTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
+        program.accept(visitor);
 
-        assertDoesNotThrow(() -> program.accept(visitor));
+        assertFalse(errorHandler.hasError());
         assertTrue(methodInvocation.getDefinition() instanceof StandardLibraryMethodNode);
     }
 
@@ -74,6 +77,7 @@ public class DetailedNameTypeAstVisitorSystemTest {
     public void testSystemCall_CorrectStaticMethod() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
 
         ClassNode _class;
         MethodInvocationExpressionNode methodInvocation;
@@ -97,9 +101,10 @@ public class DetailedNameTypeAstVisitorSystemTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
+        program.accept(visitor);
 
-        assertDoesNotThrow(() -> program.accept(visitor));
+        assertFalse(errorHandler.hasError());
         assertTrue(methodInvocation.getDefinition() instanceof StandardLibraryMethodNode);
     }
 
@@ -107,6 +112,7 @@ public class DetailedNameTypeAstVisitorSystemTest {
     public void testSystemCall_WrongNumberOfArguments() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
 
         ClassNode _class;
         MethodInvocationExpressionNode methodInvocation;
@@ -131,9 +137,10 @@ public class DetailedNameTypeAstVisitorSystemTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
+        program.accept(visitor);
 
-        assertThrows(SemanticException.class, () -> program.accept(visitor));
+        assertTrue(errorHandler.hasError());
         assertTrue(methodInvocation.isHasError());
     }
 
@@ -141,6 +148,7 @@ public class DetailedNameTypeAstVisitorSystemTest {
     public void testSystemCall_WrongArgumentType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
 
         ClassNode _class;
         MethodInvocationExpressionNode methodInvocation;
@@ -164,9 +172,10 @@ public class DetailedNameTypeAstVisitorSystemTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
+        program.accept(visitor);
 
-        assertThrows(SemanticException.class, () -> program.accept(visitor));
+        assertTrue(errorHandler.hasError());
         assertTrue(methodInvocation.isHasError());
     }
 
@@ -174,6 +183,7 @@ public class DetailedNameTypeAstVisitorSystemTest {
     public void testSystemCall_ArgumentTypeVoid() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
 
         ClassNode _class;
         MethodInvocationExpressionNode methodInvocation;
@@ -197,9 +207,10 @@ public class DetailedNameTypeAstVisitorSystemTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
+        program.accept(visitor);
 
-        assertThrows(SemanticException.class, () -> program.accept(visitor));
+        assertTrue(errorHandler.hasError());
         assertTrue(methodInvocation.isHasError());
     }
 
@@ -207,6 +218,7 @@ public class DetailedNameTypeAstVisitorSystemTest {
     public void testSystemCall_ShadowedByType() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
 
         ClassNode _class;
         ProgramNode program = new ProgramNode(0, 0, Arrays.asList(
@@ -229,15 +241,17 @@ public class DetailedNameTypeAstVisitorSystemTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
+        program.accept(visitor);
 
-        assertThrows(SemanticException.class, () -> program.accept(visitor));
+        assertTrue(errorHandler.hasError());
     }
 
     @Test
     public void testSystemCall_ShadowedByField() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
 
         ClassNode _class;
         ProgramNode program = new ProgramNode(0, 0, Arrays.asList(
@@ -262,15 +276,17 @@ public class DetailedNameTypeAstVisitorSystemTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
+        program.accept(visitor);
 
-        assertThrows(SemanticException.class, () -> program.accept(visitor));
+        assertTrue(errorHandler.hasError());
     }
 
     @Test
     public void testSystemCall_ShadowedByFieldStaticMethod() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
 
         ClassNode _class;
         ProgramNode program = new ProgramNode(0, 0, Arrays.asList(
@@ -295,15 +311,17 @@ public class DetailedNameTypeAstVisitorSystemTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
+        program.accept(visitor);
 
-        assertThrows(SemanticException.class, () -> program.accept(visitor));
+        assertTrue(errorHandler.hasError());
     }
 
     @Test
     public void testSystemCall_ShadowedByParameter() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
 
         ClassNode _class;
         ProgramNode program = new ProgramNode(0, 0, Arrays.asList(
@@ -328,15 +346,17 @@ public class DetailedNameTypeAstVisitorSystemTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
+        program.accept(visitor);
 
-        assertThrows(SemanticException.class, () -> program.accept(visitor));
+        assertTrue(errorHandler.hasError());
     }
 
     @Test
     public void testSystemCall_ShadowedByLocalVariable() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
 
         ClassNode _class;
         ProgramNode program = new ProgramNode(0, 0, Arrays.asList(
@@ -360,15 +380,17 @@ public class DetailedNameTypeAstVisitorSystemTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
+        program.accept(visitor);
 
-        assertThrows(SemanticException.class, () -> program.accept(visitor));
+        assertTrue(errorHandler.hasError());
     }
 
     @Test
     public void testSystemCall_ShadowedButCorrect() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
 
         ClassNode _class;
         MethodInvocationExpressionNode methodInvocation;
@@ -400,9 +422,10 @@ public class DetailedNameTypeAstVisitorSystemTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
+        program.accept(visitor);
 
-        assertDoesNotThrow(() -> program.accept(visitor));
+        assertFalse(errorHandler.hasError());
         assertFalse(methodInvocation.getDefinition() instanceof StandardLibraryMethodNode);
     }
 
@@ -410,6 +433,7 @@ public class DetailedNameTypeAstVisitorSystemTest {
     public void testSystemIsNotAnObject() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
 
         ClassNode _class;
         ProgramNode program = new ProgramNode(0, 0, Arrays.asList(
@@ -429,15 +453,17 @@ public class DetailedNameTypeAstVisitorSystemTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
+        program.accept(visitor);
 
-        assertThrows(SemanticException.class, () -> program.accept(visitor));
+        assertTrue(errorHandler.hasError());
     }
 
     @Test
     public void testSystemOutIsNotAnObject() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
 
         ClassNode _class;
         ProgramNode program = new ProgramNode(0, 0, Arrays.asList(
@@ -461,9 +487,10 @@ public class DetailedNameTypeAstVisitorSystemTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
+        program.accept(visitor);
 
-        assertThrows(SemanticException.class, () -> program.accept(visitor));
+        assertTrue(errorHandler.hasError());
     }
 
 }

--- a/src/test/java/edu/kit/compiler/semantic/DetailedNameTypeAstVisitorTest.java
+++ b/src/test/java/edu/kit/compiler/semantic/DetailedNameTypeAstVisitorTest.java
@@ -16,6 +16,7 @@ import edu.kit.compiler.data.ast_nodes.StatementNode.BlockStatementNode;
 import edu.kit.compiler.data.ast_nodes.StatementNode.ExpressionStatementNode;
 import edu.kit.compiler.data.ast_nodes.StatementNode.LocalVariableDeclarationStatementNode;
 import edu.kit.compiler.lexer.StringTable;
+import edu.kit.compiler.logger.Logger;
 import edu.kit.compiler.semantic.NamespaceMapper.ClassNamespace;
 import org.junit.jupiter.api.Test;
 
@@ -46,7 +47,8 @@ public class DetailedNameTypeAstVisitorTest {
     public void testAllUsedVariablesReferenceTheirDeclaration_Field() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ClassNodeField definition;
         IdentifierExpressionNode usage;
@@ -74,7 +76,8 @@ public class DetailedNameTypeAstVisitorTest {
     public void testAllUsedVariablesReferenceTheirDeclaration_MethodParameter() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         MethodNodeParameter definition;
         IdentifierExpressionNode usage;
@@ -102,7 +105,8 @@ public class DetailedNameTypeAstVisitorTest {
     public void testAllUsedVariablesReferenceTheirDeclaration_LocalVariableOuterScope() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         LocalVariableDeclarationStatementNode definition;
         IdentifierExpressionNode usage;
@@ -131,7 +135,8 @@ public class DetailedNameTypeAstVisitorTest {
     public void testAllUsedVariablesReferenceTheirDeclaration_LocalVariableCurrentScope() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         LocalVariableDeclarationStatementNode definition;
         IdentifierExpressionNode usage;
@@ -158,7 +163,8 @@ public class DetailedNameTypeAstVisitorTest {
     public void testAllUsedVariablesReferenceTheirDeclaration_FieldAndLocalVariable() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         LocalVariableDeclarationStatementNode definition;
         IdentifierExpressionNode usage;
@@ -187,7 +193,8 @@ public class DetailedNameTypeAstVisitorTest {
     public void testAllUsedVariablesReferenceTheirDeclaration_NoDefinition() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         IdentifierExpressionNode usage;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -202,7 +209,9 @@ public class DetailedNameTypeAstVisitorTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(usage.isHasError());
     }
 
@@ -210,7 +219,8 @@ public class DetailedNameTypeAstVisitorTest {
     public void testAllUsedVariablesReferenceTheirDeclaration_LocalVariableInOwnExpression() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         LocalVariableDeclarationStatementNode definition;
         IdentifierExpressionNode usage;
@@ -236,7 +246,8 @@ public class DetailedNameTypeAstVisitorTest {
     public void testNoVariableIsDeclaredTwiceInsideTheSameScope_SameScope() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         LocalVariableDeclarationStatementNode localVariable;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -250,7 +261,9 @@ public class DetailedNameTypeAstVisitorTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(localVariable.isHasError());
     }
 
@@ -258,7 +271,8 @@ public class DetailedNameTypeAstVisitorTest {
     public void testNoVariableIsDeclaredTwiceInsideTheSameScope_DifferentScopes() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         LocalVariableDeclarationStatementNode localVariable;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -274,7 +288,9 @@ public class DetailedNameTypeAstVisitorTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(localVariable.isHasError());
     }
 
@@ -282,7 +298,8 @@ public class DetailedNameTypeAstVisitorTest {
     public void testNoVariableIsDeclaredTwiceInsideTheSameScope_Parameter() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         LocalVariableDeclarationStatementNode localVariable;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(), Arrays.asList(
@@ -297,7 +314,9 @@ public class DetailedNameTypeAstVisitorTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(localVariable.isHasError());
     }
 
@@ -305,7 +324,8 @@ public class DetailedNameTypeAstVisitorTest {
     public void testStaticMethodContainsNoReferenceToThis() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ThisExpressionNode _this;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(
@@ -320,7 +340,9 @@ public class DetailedNameTypeAstVisitorTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(_this.isHasError());
     }
 
@@ -328,7 +350,8 @@ public class DetailedNameTypeAstVisitorTest {
     public void testStaticMethodCannotReferenceFields() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         IdentifierExpressionNode identifier;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(
@@ -345,7 +368,9 @@ public class DetailedNameTypeAstVisitorTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(identifier.isHasError());
     }
 
@@ -353,7 +378,8 @@ public class DetailedNameTypeAstVisitorTest {
     public void testIntegerLiteralValueIsValid_SmallPositive() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ValueExpressionNode integerValue;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(
@@ -368,7 +394,9 @@ public class DetailedNameTypeAstVisitorTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(integerValue.isHasError());
     }
 
@@ -376,7 +404,8 @@ public class DetailedNameTypeAstVisitorTest {
     public void testIntegerLiteralValueIsValid_SmallNegative() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ValueExpressionNode integerValue;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(
@@ -391,7 +420,9 @@ public class DetailedNameTypeAstVisitorTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(integerValue.isHasError());
     }
 
@@ -399,7 +430,8 @@ public class DetailedNameTypeAstVisitorTest {
     public void testIntegerLiteralValueIsValid_LargePositiveValid() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ValueExpressionNode integerValue;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(
@@ -414,7 +446,9 @@ public class DetailedNameTypeAstVisitorTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(integerValue.isHasError());
     }
 
@@ -422,7 +456,8 @@ public class DetailedNameTypeAstVisitorTest {
     public void testIntegerLiteralValueIsValid_LargeNegativeValid() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ValueExpressionNode integerValue;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(
@@ -437,7 +472,9 @@ public class DetailedNameTypeAstVisitorTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertDoesNotThrow(() -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertFalse(errorHandler.hasError());
         assertFalse(integerValue.isHasError());
     }
 
@@ -445,7 +482,8 @@ public class DetailedNameTypeAstVisitorTest {
     public void testIntegerLiteralValueIsValid_LargePositiveInvalid() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ValueExpressionNode integerValue;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(
@@ -460,7 +498,9 @@ public class DetailedNameTypeAstVisitorTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(integerValue.isHasError());
     }
 
@@ -468,7 +508,8 @@ public class DetailedNameTypeAstVisitorTest {
     public void testIntegerLiteralValueIsValid_LargeNegativeInvalid() {
         NamespaceMapper namespaceMapper = new NamespaceMapper();
         StringTable stringTable = new StringTable();
-        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable);
+        ErrorHandler errorHandler = new ErrorHandler(Logger.nullLogger());
+        DetailedNameTypeAstVisitor visitor = new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler);
 
         ValueExpressionNode integerValue;
         ClassNode _class = new ClassNode(0, 0, stringTable.insert("ClassA"), Arrays.asList(), Arrays.asList(
@@ -483,7 +524,9 @@ public class DetailedNameTypeAstVisitorTest {
 
         initializeNamespace(namespaceMapper, _class);
 
-        assertThrows(SemanticException.class, () -> _class.accept(visitor));
+        _class.accept(visitor);
+
+        assertTrue(errorHandler.hasError());
         assertTrue(integerValue.isHasError());
     }
 

--- a/src/test/java/edu/kit/compiler/semantic/SemanticChecksTest.java
+++ b/src/test/java/edu/kit/compiler/semantic/SemanticChecksTest.java
@@ -30,7 +30,7 @@ public class SemanticChecksTest {
         node.accept(visitor1);
         if (nameTypeCheck) {
             try {
-                DetailedNameTypeAstVisitor visitor2 = new DetailedNameTypeAstVisitor(namespaceMapper, lexer.getStringTable());
+                DetailedNameTypeAstVisitor visitor2 = new DetailedNameTypeAstVisitor(namespaceMapper, lexer.getStringTable(), errorHandler);
                 node.accept(visitor2);
             } catch (SemanticException e) {
                 assert(hasError);

--- a/src/test/java/edu/kit/compiler/transform/IRBooleanExpressionsTest.java
+++ b/src/test/java/edu/kit/compiler/transform/IRBooleanExpressionsTest.java
@@ -40,7 +40,7 @@ public class IRBooleanExpressionsTest {
             namespaceMapper, lexer.getStringTable(), errorHandler
         );
         node.accept(visitor);
-        DetailedNameTypeAstVisitor dntv = new DetailedNameTypeAstVisitor(namespaceMapper, lexer.getStringTable());
+        DetailedNameTypeAstVisitor dntv = new DetailedNameTypeAstVisitor(namespaceMapper, lexer.getStringTable(), errorHandler);
         node.accept(dntv);
         this.typeMapper = new TypeMapper(namespaceMapper, lexer.getStringTable());
         for (ClassNode classNode: node.getClasses()) {

--- a/src/test/java/edu/kit/compiler/transform/IRExpressionVisitorTest.java
+++ b/src/test/java/edu/kit/compiler/transform/IRExpressionVisitorTest.java
@@ -39,7 +39,7 @@ public class IRExpressionVisitorTest {
                 namespaceMapper, lexer.getStringTable(), errorHandler
         );
         ast.accept(visitor);
-        DetailedNameTypeAstVisitor dntv = new DetailedNameTypeAstVisitor(namespaceMapper, lexer.getStringTable());
+        DetailedNameTypeAstVisitor dntv = new DetailedNameTypeAstVisitor(namespaceMapper, lexer.getStringTable(), errorHandler);
         ast.accept(dntv);
 
         this.typeMapper = new TypeMapper(namespaceMapper, lexer.getStringTable());

--- a/src/test/java/edu/kit/compiler/transform/IRPointerVisitorTest.java
+++ b/src/test/java/edu/kit/compiler/transform/IRPointerVisitorTest.java
@@ -38,7 +38,7 @@ public class IRPointerVisitorTest {
             namespaceMapper, lexer.getStringTable(), errorHandler
         );
         node.accept(visitor);
-        DetailedNameTypeAstVisitor dntv = new DetailedNameTypeAstVisitor(namespaceMapper, lexer.getStringTable());
+        DetailedNameTypeAstVisitor dntv = new DetailedNameTypeAstVisitor(namespaceMapper, lexer.getStringTable(), errorHandler);
         node.accept(dntv);
         TypeMapper typeMapper = new TypeMapper(namespaceMapper, lexer.getStringTable());
         for (ClassNode classNode: node.getClasses()) {

--- a/src/test/java/edu/kit/compiler/transform/IRStatementVisitorTest.java
+++ b/src/test/java/edu/kit/compiler/transform/IRStatementVisitorTest.java
@@ -33,7 +33,7 @@ public class IRStatementVisitorTest {
             namespaceMapper, lexer.getStringTable(), errorHandler
         );
         node.accept(visitor);
-        DetailedNameTypeAstVisitor dntv = new DetailedNameTypeAstVisitor(namespaceMapper, lexer.getStringTable());
+        DetailedNameTypeAstVisitor dntv = new DetailedNameTypeAstVisitor(namespaceMapper, lexer.getStringTable(), errorHandler);
         node.accept(dntv);
         this.typeMapper = new TypeMapper(namespaceMapper, lexer.getStringTable());
         for (ClassNode classNode: node.getClasses()) {

--- a/src/test/java/edu/kit/compiler/transform/IRVisitorTest.java
+++ b/src/test/java/edu/kit/compiler/transform/IRVisitorTest.java
@@ -36,7 +36,7 @@ public class IRVisitorTest {
                 namespaceMapper, lexer.getStringTable(), errorHandler
         );
         ast.accept(visitor);
-        DetailedNameTypeAstVisitor dntv = new DetailedNameTypeAstVisitor(namespaceMapper, lexer.getStringTable());
+        DetailedNameTypeAstVisitor dntv = new DetailedNameTypeAstVisitor(namespaceMapper, lexer.getStringTable(), errorHandler);
         ast.accept(dntv);
 
         IRVisitor irv = new IRVisitor(namespaceMapper, lexer.getStringTable());

--- a/src/test/java/edu/kit/compiler/transform/TypeMapperTest.java
+++ b/src/test/java/edu/kit/compiler/transform/TypeMapperTest.java
@@ -43,7 +43,7 @@ public class TypeMapperTest {
             namespaceMapper, lexer.getStringTable(), errorHandler
         );
         node.accept(visitor);
-        node.accept(new DetailedNameTypeAstVisitor(namespaceMapper, stringTable));
+        node.accept(new DetailedNameTypeAstVisitor(namespaceMapper, stringTable, errorHandler));
         typeMapper = new TypeMapper(namespaceMapper, lexer.getStringTable());
         Dump.dumpTypeGraph("type.vcg");
     }


### PR DESCRIPTION
closes #60 

fixed bugs:
- for a default binary expression with an incompatible type on the right side of the operator, the error message included the type of the expression on the left side
- if a method invocation had too many arguments, the nodes of the additional arguments were not visited