### PR TITLE
Fix graph generation for local variable declarations

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -67,6 +67,11 @@ jobs:
           pwd
           ./run_mjtests.sh compile-firm
 
+      - name: Run Compile only Tests
+        run: |
+          pwd
+          ./run_mjtests.sh compile-only
+
       - name: Run Compile Tests
         run: |
           pwd

--- a/mjtest-files/semantic/IndefiniteAssignment.valid.mj
+++ b/mjtest-files/semantic/IndefiniteAssignment.valid.mj
@@ -1,0 +1,6 @@
+class q {
+    public q x;
+    public static void main(String[] args) {
+        q q = (q.x = null).x;
+    }
+}


### PR DESCRIPTION
This PR fixes a bug relating to the code transformation of local variable declarations. As the definite assignment rules of Java do not apply in MiniJava, it is perfectly valid for the right side of a local variable declaration to reference the declared variable. Due to a bug in our code, this could however lead to `Unknown` nodes in the Firm graph and consequently a failure to generate code for a valid program. Consider for example the program below, where the `Load` would have an `Unknown` predecessor.

```java
class Foo {
    public Foo foo;
    public static void main(String[] args) {
        Foo foo = foo.foo;
    }
}
```


