### PR TITLE
Handle Unknown nodes during instruction selection

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -67,6 +67,11 @@ jobs:
           pwd
           ./run_mjtests.sh compile-firm
 
+      - name: Run Compile only Tests
+        run: |
+          pwd
+          ./run_mjtests.sh compile-only
+
       - name: Run Compile Tests
         run: |
           pwd

--- a/mjtest-files/semantic/IndefiniteAssignment.valid.mj
+++ b/mjtest-files/semantic/IndefiniteAssignment.valid.mj
@@ -1,0 +1,6 @@
+class q {
+    public q x;
+    public static void main(String[] args) {
+        q q = (q.x = null).x;
+    }
+}

--- a/src/main/java/edu/kit/compiler/codegen/PatternCollection.java
+++ b/src/main/java/edu/kit/compiler/codegen/PatternCollection.java
@@ -24,6 +24,7 @@ import edu.kit.compiler.codegen.pattern.Pattern;
 import edu.kit.compiler.codegen.pattern.PhiPattern;
 import edu.kit.compiler.codegen.pattern.ReturnPattern;
 import edu.kit.compiler.codegen.pattern.UnaryInstructionPattern;
+import edu.kit.compiler.codegen.pattern.UnknownPattern;
 import edu.kit.compiler.intermediate_lang.RegisterSize;
 import firm.bindings.binding_irnode.ir_opcode;
 import firm.nodes.Node;
@@ -91,7 +92,10 @@ public class PatternCollection implements Pattern<InstructionMatch> {
                 // nodes for which we never need to generate instructions
                 Map.entry(iro_Start, new EmptyPattern()),
                 Map.entry(iro_End, new InheritingPattern()),
-                Map.entry(iro_Cmp, new InheritingPattern()));
+                Map.entry(iro_Cmp, new InheritingPattern()),
+
+                // handle Unknown nodes
+                Map.entry(iro_Unknown, new UnknownPattern()));
     }
 
     /**

--- a/src/main/java/edu/kit/compiler/codegen/pattern/UnknownPattern.java
+++ b/src/main/java/edu/kit/compiler/codegen/pattern/UnknownPattern.java
@@ -1,0 +1,60 @@
+package edu.kit.compiler.codegen.pattern;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import edu.kit.compiler.codegen.MatcherState;
+import edu.kit.compiler.codegen.Operand;
+import edu.kit.compiler.codegen.Util;
+import edu.kit.compiler.intermediate_lang.Instruction;
+import firm.bindings.binding_irnode.ir_opcode;
+import firm.nodes.Node;
+import lombok.RequiredArgsConstructor;
+
+public final class UnknownPattern implements Pattern<InstructionMatch> {
+
+    @Override
+    public InstructionMatch match(Node node, MatcherState matcher) {
+        if (node.getOpCode() == ir_opcode.iro_Unknown) {
+            var size = Util.getSize(node.getMode());
+            var targetRegister = matcher.getNewRegister(size);
+            return new UnknownMatch(node, targetRegister);
+        } else {
+            return InstructionMatch.none();
+        }
+    }
+
+    @RequiredArgsConstructor
+    private static final class UnknownMatch extends InstructionMatch.Basic {
+
+        private final Node node;
+        private final int targetRegister;
+
+        @Override
+        public Node getNode() {
+            return node;
+        }
+
+        @Override
+        public Optional<Integer> getTargetRegister() {
+            return Optional.of(targetRegister);
+        }
+
+        @Override
+        public Stream<Operand> getOperands() {
+            return Stream.empty();
+        }
+
+        @Override
+        public Stream<Node> getPredecessors() {
+            return Stream.empty();
+        }
+
+        @Override
+        public List<Instruction> getInstructions() {
+            return List.of(Instruction.newOp("nop", List.of(),
+                    Optional.empty(), targetRegister));
+        }
+    }
+}

--- a/src/main/java/edu/kit/compiler/transform/IRStatementVisitor.java
+++ b/src/main/java/edu/kit/compiler/transform/IRStatementVisitor.java
@@ -10,7 +10,6 @@ import edu.kit.compiler.data.ast_nodes.StatementNode.LocalVariableDeclarationSta
 import edu.kit.compiler.data.ast_nodes.StatementNode.ReturnStatementNode;
 import edu.kit.compiler.data.ast_nodes.StatementNode.WhileStatementNode;
 import firm.Construction;
-import firm.Mode;
 import firm.nodes.Block;
 import firm.nodes.Node;
 
@@ -41,17 +40,14 @@ public class IRStatementVisitor implements AstVisitor<Boolean> {
 
     @Override
     public Boolean visit(LocalVariableDeclarationStatementNode stmt) {
-        Construction con = context.getConstruction();
-        Node assignedVal;
+        // using a variable before initialization will result in a Unknown node
         if (stmt.getExpression().isPresent()) {
-            assignedVal = evalExpression(stmt.getExpression().get());
-        } else {
-            // zero-initialize the variable
-            // Note: for debugging, me might want to make no assignment
-            Mode mode = context.getTypeMapper().getMode(stmt.getType());
-            assignedVal = con.newConst(0, mode);
+            Construction con = context.getConstruction();
+            int variableIndex = context.getVariableIndex(stmt.getName());
+            Node assignedValue = evalExpression(stmt.getExpression().get());
+            con.setVariable(variableIndex, assignedValue);
         }
-        con.setVariable(context.getVariableIndex(stmt.getName()), assignedVal);
+
         return false;
     }
 


### PR DESCRIPTION
The instruction selection must be able to deal with `Unknown` nodes. `Unknown` nodes may for example result from using the value of a local variable prior to assignment. As the definite assignment rules of Java don't apply in MiniJava, our compiler must be able to generate code for such programs.