### PR TITLE
Improve usage of addressing modes

### DIFF
--- a/src/main/java/edu/kit/compiler/optimizations/ArithmeticIdentitiesOptimization.java
+++ b/src/main/java/edu/kit/compiler/optimizations/ArithmeticIdentitiesOptimization.java
@@ -4,7 +4,6 @@ import java.util.function.BinaryOperator;
 
 import edu.kit.compiler.io.StackWorklist;
 import edu.kit.compiler.io.Worklist;
-import firm.BackEdges;
 import firm.Graph;
 import firm.Mode;
 import firm.TargetValue;
@@ -51,15 +50,8 @@ import lombok.RequiredArgsConstructor;
 public final class ArithmeticIdentitiesOptimization implements Optimization {
     @Override
     public boolean optimize(Graph graph) {
-        boolean backEdgesEnabled = BackEdges.enabled(graph);
-        BackEdges.enable(graph);
-
         var visitor = new Visitor(graph);
         visitor.apply();
-
-        if (!backEdgesEnabled) {
-            BackEdges.disable(graph);
-        }
 
         return visitor.isChanges();
     }

--- a/src/main/java/edu/kit/compiler/optimizations/ArithmeticReplacementOptimization.java
+++ b/src/main/java/edu/kit/compiler/optimizations/ArithmeticReplacementOptimization.java
@@ -4,7 +4,6 @@ import java.util.Optional;
 
 import edu.kit.compiler.io.StackWorklist;
 import edu.kit.compiler.io.Worklist;
-import firm.BackEdges;
 import firm.Graph;
 import firm.Mode;
 import firm.TargetValue;
@@ -42,15 +41,8 @@ public class ArithmeticReplacementOptimization implements Optimization {
 
     @Override
     public boolean optimize(Graph graph) {
-        boolean backEdgesEnabled = BackEdges.enabled(graph);
-        BackEdges.enable(graph);
-
         var visitor = new Visitor(graph);
         visitor.apply();
-
-        if (!backEdgesEnabled) {
-            BackEdges.disable(graph);
-        }
 
         return visitor.hasChanged;
     }


### PR DESCRIPTION
This PR implements two small transformations to the Firm graph. When combined these lead to better usage of addressing modes in certain situations. For example the following function will translate to something like `movl 16(%rsi,%rdx,4), %eax`.

```java
public int foo(int[] arr, int i) {
    return arr[i + 4];
}
```