### PR TITLE
Assume that array indizes are always positive

### DIFF
--- a/src/main/java/edu/kit/compiler/optimizations/ArithmeticIdentitiesOptimization.java
+++ b/src/main/java/edu/kit/compiler/optimizations/ArithmeticIdentitiesOptimization.java
@@ -344,9 +344,11 @@ public final class ArithmeticIdentitiesOptimization implements Optimization {
         }
 
         /**
-         * Exchanges a conv node which operand is an add with a constant as rhs.
+         * Exchanges a conversion to Ls which operand is an add with a constant rhs.
          */
         private void exchangeConv(Node node, Node opNode, Node offsetNode) {
+            assert node.getMode().equals(Mode.getLs());
+
             var block = node.getBlock();
             var op = graph.newConv(block, opNode, Mode.getLs());
             var offsetValue = ((Const) offsetNode).getTarval();

--- a/src/test/java/edu/kit/compiler/optimizations/ArithmeticIdentitiesOptimizationTest.java
+++ b/src/test/java/edu/kit/compiler/optimizations/ArithmeticIdentitiesOptimizationTest.java
@@ -275,9 +275,21 @@ public class ArithmeticIdentitiesOptimizationTest {
     }
 
     @Test
-    public void testConvAdd() {
+    public void testConvAddLs() {
         createConstBOp(initGraph(Mode.getLs()), 42, false, (con, lhs, rhs) -> {
             return con.newAdd(con.newConv(con.newAdd(lhs, rhs), Mode.getLs()), con.newConst(28, Mode.getLs()));
+        });
+        optimization.optimize(graph());
+        assertEquals(1, count(ir_opcode.iro_Conv));
+        assertEquals(1, count(ir_opcode.iro_Add));
+        assertEquals(1, count(ir_opcode.iro_Const));
+    }
+
+    @Test
+    public void testConvAddLu() {
+        createConstBOp(initGraph(Mode.getLs()), 42, false, (con, lhs, rhs) -> {
+            return con.newAdd(con.newConv(con.newConv(con.newAdd(lhs, rhs), Mode.getLu()), Mode.getLs()),
+                    con.newConst(28, Mode.getLs()));
         });
         optimization.optimize(graph());
         assertEquals(1, count(ir_opcode.iro_Conv));


### PR DESCRIPTION
Negative indizes are undefined behavior in MiniJava. We can use this to avoid emitting an unnecessary `movslq`.

Note: This does not work if the conversion is propagated to operands, because operands on their own might still be negative.