### PR TITLE
Add `lea` pattern to instruction selection

### DIFF
--- a/mjtest-files/compile/pattern/LoadEffective.java
+++ b/mjtest-files/compile/pattern/LoadEffective.java
@@ -1,0 +1,79 @@
+class Main {
+    public static void main(String[] args) {
+        Main m = new Main();
+
+        System.out.println(m.baseOffset(0));
+        System.out.println(m.baseOffset(128));
+        System.out.println(m.baseOffset(-1234));
+
+        System.out.println(m.baseIndex(0, 42));
+        System.out.println(m.baseIndex(128, 28));
+        System.out.println(m.baseIndex(-1234, 43));
+
+        System.out.println(m.baseIndexOffset(0, 42));
+        System.out.println(m.baseIndexOffset(128, 28));
+        System.out.println(m.baseIndexOffset(-1234, 43));
+
+        System.out.println(m.index2(0));
+        System.out.println(m.index2(128));
+        System.out.println(m.index2(-1234));
+
+        System.out.println(m.index4(0));
+        System.out.println(m.index4(128));
+        System.out.println(m.index4(-1234));
+
+        System.out.println(m.index8(0));
+        System.out.println(m.index8(128));
+        System.out.println(m.index8(-1234));
+
+        System.out.println(m.baseIndexScale(0, 42));
+        System.out.println(m.baseIndexScale(128, 28));
+        System.out.println(m.baseIndexScale(-1234, 43));
+
+        System.out.println(m.baseIndexScaleOffset(0, 42));
+        System.out.println(m.baseIndexScaleOffset(128, 28));
+        System.out.println(m.baseIndexScaleOffset(-1234, 43));
+
+        System.out.println(m.indexScaleOffset(0));
+        System.out.println(m.indexScaleOffset(128));
+        System.out.println(m.indexScaleOffset(-1234));
+
+
+    }
+
+    public int baseOffset(int x) {
+        return x + 1337;
+    }
+
+    public int baseIndex(int x, int y) {
+        return x + y;
+    }
+
+    public int baseIndexOffset(int x, int y) {
+        return x + y + 1337;
+    }
+
+    public int index2(int x) {
+        return x * 2;
+    }
+
+    public int index4(int x) {
+        return x * 4;
+    }
+
+    public int index8(int x) {
+        return x * 8;
+    }
+
+    public int baseIndexScale(int x, int y) {
+        return x + y * 8;
+    }
+
+    public int baseIndexScaleOffset(int x, int y) {
+        return -42 + x + y * 8;
+    }
+
+    public int indexScaleOffset(int x) {
+        return -42 + x * 8;
+    }
+}

--- a/src/main/java/edu/kit/compiler/codegen/Operand.java
+++ b/src/main/java/edu/kit/compiler/codegen/Operand.java
@@ -45,13 +45,6 @@ public interface Operand {
     }
 
     /**
-     * If the operand is an immediate, return its TargetValue.
-     */
-    default Optional<TargetValue> getConstValue() {
-        return Optional.empty();
-    }
-
-    /**
      * Return an Operand equivalent to an immediate of the given TargetValue.
      * The size of the value is used to determine the size of the operand.
      */
@@ -97,9 +90,9 @@ public interface Operand {
      * Illegal combinations of present (or rather absent) values will result
      * in exceptions being thrown.
      */
-    public static Memory memory(Optional<Integer> offset, Optional<Register> base,
+    public static Memory memory(Mode mode, Optional<Integer> offset, Optional<Register> base,
             Optional<Register> index, Optional<Integer> scale) {
-        return new Memory(offset, base, index, scale);
+        return new Memory(mode, offset, base, index, scale);
     }
 
     /**
@@ -151,11 +144,6 @@ public interface Operand {
         @Override
         public List<Integer> getSourceRegisters() {
             return List.of();
-        }
-
-        @Override
-        public Optional<TargetValue> getConstValue() {
-            return Optional.of(value);
         }
 
         /**
@@ -219,8 +207,6 @@ public interface Operand {
     @ToString(callSuper = true)
     public static final class ImmediateRegister extends Register {
 
-        // ? would is make sense for getConstValue return the Tarval ?
-
         private final Immediate value;
 
         public ImmediateRegister(Immediate value, int register) {
@@ -250,18 +236,20 @@ public interface Operand {
     @ToString
     public static final class Memory implements Target {
 
+        private final Mode mode;
         private final Optional<Integer> offset;
         private final Optional<Register> baseRegister;
         private final Optional<Register> indexRegister;
         private final Optional<Integer> scale;
 
-        public Memory(Optional<Integer> offset, Optional<Register> baseRegister,
+        public Memory(Mode mode, Optional<Integer> offset, Optional<Register> baseRegister,
                 Optional<Register> indexRegister, Optional<Integer> scale) {
             if (baseRegister.isEmpty() && indexRegister.isEmpty()) {
                 throw new IllegalArgumentException("either base or index register must be present");
             } else if (scale.isPresent() && indexRegister.isEmpty()) {
                 throw new IllegalArgumentException("scale required index register to be present");
             } else {
+                this.mode = mode;
                 this.offset = offset;
                 this.baseRegister = baseRegister;
                 this.indexRegister = indexRegister;
@@ -293,12 +281,12 @@ public interface Operand {
 
         @Override
         public RegisterSize getSize() {
-            return Util.getSize(Mode.getP());
+            return Util.getSize(mode);
         }
 
         @Override
         public Mode getMode() {
-            return Mode.getP();
+            return mode;
         }
 
         @Override

--- a/src/main/java/edu/kit/compiler/codegen/PatternCollection.java
+++ b/src/main/java/edu/kit/compiler/codegen/PatternCollection.java
@@ -17,6 +17,7 @@ import edu.kit.compiler.codegen.pattern.ConversionPattern;
 import edu.kit.compiler.codegen.pattern.DivisionPattern;
 import edu.kit.compiler.codegen.pattern.DivisionPattern.Type;
 import edu.kit.compiler.codegen.pattern.InstructionMatch;
+import edu.kit.compiler.codegen.pattern.LoadEffectivePattern;
 import edu.kit.compiler.codegen.pattern.LoadMemoryPattern;
 import edu.kit.compiler.codegen.pattern.OperandMatch;
 import edu.kit.compiler.codegen.pattern.OperandPattern;
@@ -52,9 +53,13 @@ public class PatternCollection implements Pattern<InstructionMatch> {
 
     public PatternCollection() {
         map = Map.ofEntries(
-                Map.entry(iro_Add, new ArithmeticPattern(iro_Add, "add", 0, true)),
+                Map.entry(iro_Add, new CompoundPattern(List.of(
+                        new LoadEffectivePattern(),
+                        new ArithmeticPattern(iro_Add, "add", 0, true)))),
                 Map.entry(iro_Sub, new ArithmeticPattern(iro_Sub, "sub", 0, false)),
-                Map.entry(iro_Mul, new ArithmeticPattern(iro_Mul, "imul", 0, true)),
+                Map.entry(iro_Mul, new CompoundPattern(List.of(
+                    new LoadEffectivePattern(),
+                    new ArithmeticPattern(iro_Mul, "imul", 0, true)))),
                 Map.entry(iro_And, new ArithmeticPattern(iro_And, "and", 0, true)),
                 Map.entry(iro_Eor, new ArithmeticPattern(iro_Eor, "xor", 0, true)),
 

--- a/src/main/java/edu/kit/compiler/codegen/pattern/LoadEffectivePattern.java
+++ b/src/main/java/edu/kit/compiler/codegen/pattern/LoadEffectivePattern.java
@@ -1,0 +1,75 @@
+package edu.kit.compiler.codegen.pattern;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import edu.kit.compiler.codegen.MatcherState;
+import edu.kit.compiler.codegen.Operand;
+import edu.kit.compiler.codegen.Util;
+import edu.kit.compiler.intermediate_lang.Instruction;
+import edu.kit.compiler.intermediate_lang.RegisterSize;
+import firm.nodes.Node;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+public final class LoadEffectivePattern implements Pattern<InstructionMatch> {
+
+    private static final Pattern<OperandMatch<Operand.Memory>> MEMORY = OperandPattern.memory();
+
+    @Override
+    public InstructionMatch match(Node node, MatcherState matcher) {
+        var match = MEMORY.match(node, matcher);
+
+        if (match.matches()) {
+            var size = Util.getSize(node.getMode());
+
+            // x86 only supports double-and quad-words in addressing modes
+            return switch (size) {
+                case DOUBLE, QUAD -> {
+                    var targetRegister = matcher.getNewRegister(size);
+                    yield new LoadEffectiveMatch(node, match, size, targetRegister);
+                }
+                default -> InstructionMatch.none();
+            };
+        } else {
+            return InstructionMatch.none();
+        }
+    }
+
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    private final class LoadEffectiveMatch extends InstructionMatch.Basic {
+
+        private final Node node;
+        private final OperandMatch<Operand.Memory> source;
+        private final RegisterSize size;
+        private final int targetRegister;
+
+        @Override
+        public Node getNode() {
+            return node;
+        }
+
+        @Override
+        public List<Instruction> getInstructions() {
+            return List.of(Instruction.newOp(
+                    Util.formatCmd("lea", size, source.getOperand(), targetRegister),
+                    source.getOperand().getSourceRegisters(), Optional.empty(), targetRegister));
+        }
+
+        @Override
+        public Optional<Integer> getTargetRegister() {
+            return Optional.of(targetRegister);
+        }
+
+        @Override
+        public Stream<Operand> getOperands() {
+            return Stream.of(source.getOperand());
+        }
+
+        @Override
+        public Stream<Node> getPredecessors() {
+            return source.getPredecessors();
+        }
+    }
+}

--- a/src/main/java/edu/kit/compiler/codegen/pattern/OperandPattern.java
+++ b/src/main/java/edu/kit/compiler/codegen/pattern/OperandPattern.java
@@ -192,21 +192,8 @@ public final class OperandPattern {
                 return indexLeft;
             }
 
-            // ! possible improvement: (2,4,8) + 1 * %rax = (%rax,%rax,8)
-            var match = getMatch(nodes.offset, nodes.firstRegister,
+            return getMatch(nodes.offset, nodes.firstRegister,
                     nodes.secondRegister, matcher);
-            if (!match.matches()) {
-                // fallback if something goes awry
-                var register = REGISTER.match(node, matcher);
-                var operand = Operand.memory(Optional.empty(),
-                        Optional.of(register.getOperand()),
-                        Optional.empty(), Optional.empty());
-                var predecessors = register.getPredecessors()
-                        .collect(Collectors.toList());
-                return OperandMatch.some(operand, predecessors);
-            } else {
-                return match;
-            }
         }
 
         /**


### PR DESCRIPTION
This PR adds functionality to allow for the use of load effective address during instruction selection. This just reuses the memory patterns used to match `Load` nodes. Most additions of registers, additions with constants, as well as a limited number of multiplications (those with 2, 4, or 8) can now be expressed using `lea`. 

Note: There is still room for improvement here. For example multiplications by 3, 5, and 9 could also be expressed using `lea`.