### PR TITLE
Fix lifetime analysis regarding intermangled loops

### DIFF
--- a/mjtest-files/compile/LifetimeError.mj
+++ b/mjtest-files/compile/LifetimeError.mj
@@ -1,0 +1,9 @@
+class A {
+    public boolean x;
+
+    public static void main(String[] args) {
+        A a = new A();
+        a.x = false;
+        while(a.x) while(!a.x) while(a.x) System.out.println(0);
+    }
+}

--- a/mjtest-files/compile/LifetimeError2.mj
+++ b/mjtest-files/compile/LifetimeError2.mj
@@ -1,0 +1,19 @@
+class A {
+    public boolean x;
+
+    public static void main(String[] args) {
+        A a = new A();
+        a.x = false;
+        while(a.x) {
+            while(!a.x) {
+                if (a.x) {
+                    return;
+                }
+                while(a.x) System.out.println(0);
+            }
+            if (!a.x) {
+                return;
+            }
+        }
+    }
+}

--- a/src/main/java/edu/kit/compiler/codegen/ReversePostfixOrder.java
+++ b/src/main/java/edu/kit/compiler/codegen/ReversePostfixOrder.java
@@ -144,7 +144,10 @@ public class ReversePostfixOrder {
         private void depthFirstSearch(Block block, int previousId) {
             int blockId = block.getBlockId();
             if (active.contains(blockId)) {
-                block.addBackRef();
+                // we don't want to add a backref of the same block two times
+                if (!loopsPerBlock.get(blockId).contains(blockId)) {
+                    block.addBackRef();
+                }
 
                 // backtrack and add the loop to all found blocks
                 Deque<Integer> queue = new ArrayDeque<>();

--- a/src/main/java/edu/kit/compiler/codegen/ReversePostfixOrder.java
+++ b/src/main/java/edu/kit/compiler/codegen/ReversePostfixOrder.java
@@ -12,6 +12,11 @@ import java.util.*;
  * The order that is calculated:
  *  - is a reverse postfix order (and thus a topological order except for loops)
  *  - ensures that the blocks of each loop are in contiguous order without holes
+ *  - sets the number of backrefs for each loop header correctly
+ *    (backrefs = for how many loops is this block the loop header?)
+ *  - sets the loop depth of each block correctly, specifically ensuring that e.g.
+ *    a return block that is embedded in a loop is assigned the same loop depth
+ *    as the surrounding blocks in the loop
  *
  *  This is (more or less) the best possible block layout for linear scan register
  *  allocation. However, the second condition is surprisingly hard to correctly
@@ -22,18 +27,19 @@ import java.util.*;
 public class ReversePostfixOrder {
     private Map<Integer, Block> blocks;
     private Set<Integer> visited = new HashSet<>();
-    private Map<Integer, Integer> blockLoopDepth;
+    private Map<Integer, Set<Integer>> loopsPerBlock;
 
-    private ReversePostfixOrder(Map<Integer, Block> blocks, Map<Integer, Integer> blockLoopDepth) {
+    private ReversePostfixOrder(Map<Integer, Block> blocks, Map<Integer, Set<Integer>> loopsPerBlock) {
         this.blocks = blocks;
-        this.blockLoopDepth = blockLoopDepth;
+        this.loopsPerBlock = loopsPerBlock;
     }
 
     public static List<Block> apply(Map<Integer, Block> blocks, int startBlock) {
-        Map<Integer, Integer> blockLoopDepth = new LoopDepthAnalysis(blocks).run(startBlock);
+        var loopsPerBlock = new LoopDepthAnalysis(blocks).run(startBlock);
 
-        ReversePostfixOrder instance = new ReversePostfixOrder(blocks, blockLoopDepth);
+        ReversePostfixOrder instance = new ReversePostfixOrder(blocks, loopsPerBlock);
         List<Block> result = instance.depthFirstSearch(blocks.get(startBlock)).getResult();
+        instance.setFinalLoopDepth(result);
 
         List<Block> reversed = new ArrayList<>();
         for (int i = result.size() - 1; i >= 0; i--) {
@@ -61,7 +67,8 @@ public class ReversePostfixOrder {
         // It is important that the loop body is arranged before the loop exit,
         // to enable efficient lifetime analysis.
         boolean outputInReverseOrder = (children.size() == 2) &&
-                blockLoopDepth.get(children.get(0).getBlockId()) > blockLoopDepth.get(children.get(1).getBlockId());
+                loopsPerBlock.get(children.get(0).getBlockId()).size()
+                        > loopsPerBlock.get(children.get(1).getBlockId()).size();
         if (outputInReverseOrder) {
             var tmp = children.get(0);
             children.set(0, children.get(1));
@@ -85,6 +92,50 @@ public class ReversePostfixOrder {
 
         result.add(block);
         return new DFSResult(block.getBlockId(), result);
+    }
+
+    /**
+     * Calculates the loop depth of all blocks. Also,
+     * "flattens" the loop depth for e.g. return blocks within a loop.
+     * This is necessary so that the lifetime analysis can detect loops
+     * correctly.
+     */
+    private void setFinalLoopDepth(List<Block> blocks) {
+        Set<Integer> visitedLabels = new HashSet<>();
+        Set<Integer> previousLabels = Set.of();
+        for (int i = 0; i < blocks.size(); i++) {
+            // iterate through all blocks and look for new labels
+            Block b = blocks.get(i);
+            Set<Integer> currentLabels = loopsPerBlock.get(b.getBlockId());
+            if (!currentLabels.equals(previousLabels)) {
+                Set<Integer> difference = new HashSet<>(currentLabels);
+                difference.removeAll(previousLabels);
+                for (int label: difference) {
+                    if (visitedLabels.contains(label)) {
+                        // we need to fill the "hole" in the loop labels
+                        addLabelBackwards(blocks, label, i - 1);
+                    } else {
+                        visitedLabels.add(label);
+                    }
+                }
+            }
+        }
+
+        for (Block b: blocks) {
+            int depth = loopsPerBlock.get(b.getBlockId()).size();
+            b.setBlockLoopDepth(depth);
+        }
+    }
+
+    private void addLabelBackwards(List<Block> blocks, int label, int lastIndex) {
+        for (int j = lastIndex;;  j--) {
+            Set<Integer> currentLabels = loopsPerBlock.get(blocks.get(j).getBlockId());
+            if (currentLabels.contains(label)) {
+                break;
+            } else {
+                currentLabels.add(label);
+            }
+        }
     }
 
     @Data
@@ -129,16 +180,9 @@ public class ReversePostfixOrder {
             }
         }
 
-        public Map<Integer, Integer> run(int startBlock) {
+        public Map<Integer, Set<Integer>> run(int startBlock) {
             depthFirstSearch(blocks.get(startBlock), -1);
-
-            Map<Integer, Integer> loopDepths = new HashMap<>();
-            for (var entry: loopsPerBlock.entrySet()) {
-                int depth = entry.getValue().size();
-                loopDepths.put(entry.getKey(), depth);
-                blocks.get(entry.getKey()).setBlockLoopDepth(depth);
-            }
-            return loopDepths;
+            return loopsPerBlock;
         }
 
         private void depthFirstSearch(Block block, int previousId) {

--- a/src/main/java/edu/kit/compiler/codegen/ReversePostfixOrder.java
+++ b/src/main/java/edu/kit/compiler/codegen/ReversePostfixOrder.java
@@ -134,7 +134,9 @@ public class ReversePostfixOrder {
 
             Map<Integer, Integer> loopDepths = new HashMap<>();
             for (var entry: loopsPerBlock.entrySet()) {
-                loopDepths.put(entry.getKey(), entry.getValue().size());
+                int depth = entry.getValue().size();
+                loopDepths.put(entry.getKey(), depth);
+                blocks.get(entry.getKey()).setBlockLoopDepth(depth);
             }
             return loopDepths;
         }

--- a/src/main/java/edu/kit/compiler/intermediate_lang/Block.java
+++ b/src/main/java/edu/kit/compiler/intermediate_lang/Block.java
@@ -2,6 +2,7 @@ package edu.kit.compiler.intermediate_lang;
 
 import lombok.Data;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,11 +24,15 @@ public class Block {
      */
     @Getter
     private int numBackReferences;
+    @Getter
+    @Setter
+    private int blockLoopDepth;
 
     public Block(List<Instruction> instructions, int blockId, int numBackReferences) {
         this.instructions = new ArrayList<>(instructions);
         this.blockId = blockId;
         this.numBackReferences = numBackReferences;
+        this.blockLoopDepth = 0;
     }
 
     public Block(int blockId) {

--- a/src/main/java/edu/kit/compiler/register_allocation/LifetimeAnalysis.java
+++ b/src/main/java/edu/kit/compiler/register_allocation/LifetimeAnalysis.java
@@ -16,23 +16,32 @@ public class LifetimeAnalysis {
     private Optional<Instruction>[] firstInstruction;
     private Optional<Instruction>[] lastInstruction;
     private int[] loopNestingDepth;
+    private int[] definitionNestingDepth;
     private boolean[] isDividend;
     private List<Integer> callsPrefixSum;
     private List<Integer> divsPrefixSum;
     @Getter
     private int numInstructions;
 
-    private LifetimeAnalysis(Lifetime[] lifetimes, Optional<Instruction>[] firstInstruction,
-                             Optional<Instruction>[] lastInstruction, int[] loopNestingDepth, boolean[] isDividend,
-                             List<Integer> callsPrefixSum, List<Integer> divsPrefixSum, int numInstructions) {
-        this.lifetimes = lifetimes;
-        this.firstInstruction = firstInstruction;
-        this.lastInstruction = lastInstruction;
-        this.loopNestingDepth = loopNestingDepth;
-        this.isDividend = isDividend;
-        this.callsPrefixSum = callsPrefixSum;
-        this.divsPrefixSum = divsPrefixSum;
-        this.numInstructions = numInstructions;
+    @SuppressWarnings("unchecked")
+    private LifetimeAnalysis(int numVRegisters) {
+        this.lifetimes = new Lifetime[numVRegisters];
+        this.firstInstruction = new Optional[numVRegisters];
+        this.lastInstruction = new Optional[numVRegisters];
+        this.loopNestingDepth = new int[numVRegisters];
+        this.definitionNestingDepth = new int[numVRegisters];
+        this.isDividend = new boolean[numVRegisters];
+        this.callsPrefixSum = new ArrayList<>();
+        callsPrefixSum.add(0);
+        this.divsPrefixSum = new ArrayList<>();
+        divsPrefixSum.add(0);
+        this.numInstructions = 0;
+
+        for (int i = 0; i < numVRegisters; i++) {
+            lifetimes[i] = new Lifetime();
+            firstInstruction[i] = Optional.empty();
+            lastInstruction[i] = Optional.empty();
+        }
     }
 
     /**
@@ -111,28 +120,21 @@ public class LifetimeAnalysis {
     }
 
     public static LifetimeAnalysis run(List<Block> ir, int numVRegisters, int nArgs) {
-        Lifetime[] lifetimes = new Lifetime[numVRegisters];
-        @SuppressWarnings("unchecked")
-        Optional<Instruction>[] firstInstruction = new Optional[numVRegisters];
-        @SuppressWarnings("unchecked")
-        Optional<Instruction>[] lastInstruction = new Optional[numVRegisters];
-        int[] loopNestingDepth = new int[numVRegisters];
-        int[] definitionNestingDepth = new int[numVRegisters];
-        boolean[] isDividend = new boolean[numVRegisters];
-        List<Integer> callsPrefixSum = new ArrayList<>();
-        callsPrefixSum.add(0);
-        List<Integer> divsPrefixSum = new ArrayList<>();
-        divsPrefixSum.add(0);
+        LifetimeAnalysis analysis = new LifetimeAnalysis(numVRegisters);
+        analysis.run(ir, nArgs);
+        return analysis;
+    }
+
+    private void run(List<Block> ir, int nArgs) {
         List<StackEntry> stack = new ArrayList<>();
-
-        for (int i = 0; i < numVRegisters; i++) {
-            lifetimes[i] = new Lifetime();
-            firstInstruction[i] = Optional.empty();
-            lastInstruction[i] = Optional.empty();
-        }
-
         int index = 0;
+        int previousDepth = 0;
         for (Block b: ir) {
+            assert previousDepth == stack.size();
+            int endOfLoopDepth = b.getBlockLoopDepth() - b.getNumBackReferences();
+            handleLoopEnding(index - 1, endOfLoopDepth, stack);
+            previousDepth = b.getBlockLoopDepth();
+
             for (int counter = 0; counter < b.getNumBackReferences(); counter++) {
                 stack.add(new StackEntry(b.getBlockId()));
             }
@@ -197,23 +199,23 @@ public class LifetimeAnalysis {
                     }
                 }
 
-                Optional<Integer> backref = instr.getJumpTarget();
-                if (backref.isPresent() && !stack.isEmpty() &&
-                        backref.get() == stack.get(stack.size() - 1).getBlockId()) {
-                    // loop-extension of register lifetimes
-                    StackEntry entry = stack.remove(stack.size() - 1);
-                    for (int vRegister: entry.getVRegisters()) {
-                        lifetimes[vRegister].extend(index, false);
-                        lastInstruction[vRegister] = Optional.empty();
-                    }
-                }
-
                 index++;
             }
         }
+        handleLoopEnding(index - 1, 0, stack);
         assert stack.isEmpty();
-        return new LifetimeAnalysis(lifetimes, firstInstruction, lastInstruction,
-                loopNestingDepth, isDividend, callsPrefixSum, divsPrefixSum, index);
+        numInstructions = index;
+    }
+
+    private void handleLoopEnding(int index, int newDepth, List<StackEntry> stack) {
+        while (newDepth < stack.size()) {
+            // loop ending: loop-extension of register lifetimes
+            StackEntry entry = stack.remove(stack.size() - 1);
+            for (int vRegister: entry.getVRegisters()) {
+                lifetimes[vRegister].extend(index, false);
+                lastInstruction[vRegister] = Optional.empty();
+            }
+        }
     }
 
     private int numInterferencesFromPrefixSum(List<Integer> prefixSum, int vRegister,

--- a/src/main/java/edu/kit/compiler/register_allocation/LifetimeAnalysis.java
+++ b/src/main/java/edu/kit/compiler/register_allocation/LifetimeAnalysis.java
@@ -9,6 +9,10 @@ import java.util.*;
 
 /**
  * Analyses the lifetimes and related information for all vRegisters.
+ *
+ * Precondition: The blocks need to be in reverse postfix order with
+ * loops in contiguous blocks and the correct number of backrefs and
+ * the correct loop depth needs to be set (see also ReversePostfixOrder).
  */
 public class LifetimeAnalysis {
     @Getter

--- a/src/test/java/edu/kit/compiler/codegen/ReversePostfixOrderTest.java
+++ b/src/test/java/edu/kit/compiler/codegen/ReversePostfixOrderTest.java
@@ -38,6 +38,8 @@ public class ReversePostfixOrderTest {
                 result.stream().map(Block::getBlockId).collect(Collectors.toList()));
         assertEquals(List.of(0, 0, 0, 0),
                 result.stream().map(Block::getNumBackReferences).collect(Collectors.toList()));
+        assertEquals(List.of(0, 0, 0, 0),
+                result.stream().map(Block::getBlockLoopDepth).collect(Collectors.toList()));
     }
 
     @Test
@@ -65,6 +67,8 @@ public class ReversePostfixOrderTest {
                 result.stream().map(Block::getBlockId).collect(Collectors.toList()));
         assertEquals(List.of(0, 1, 0, 0),
                 result.stream().map(Block::getNumBackReferences).collect(Collectors.toList()));
+        assertEquals(List.of(0, 1, 1, 0),
+                result.stream().map(Block::getBlockLoopDepth).collect(Collectors.toList()));
     }
 
     @Test
@@ -106,8 +110,10 @@ public class ReversePostfixOrderTest {
         var result = ReversePostfixOrder.apply(map, 0);
         assertEquals(List.of(0, 1, 3, 2, 4, 5, 7, 6, 8),
                 result.stream().map(Block::getBlockId).collect(Collectors.toList()));
-        assertEquals(List.of(0, 2, 0, 0, 0, 0, 0, 0, 0),
+        assertEquals(List.of(0, 1, 0, 0, 0, 0, 0, 0, 0),
                 result.stream().map(Block::getNumBackReferences).collect(Collectors.toList()));
+        assertEquals(List.of(0, 1, 1, 1, 1, 1, 1, 1, 0),
+                result.stream().map(Block::getBlockLoopDepth).collect(Collectors.toList()));
     }
 
     @Test
@@ -160,5 +166,7 @@ public class ReversePostfixOrderTest {
                 result.stream().map(Block::getBlockId).collect(Collectors.toList()));
         assertEquals(List.of(0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0),
                 result.stream().map(Block::getNumBackReferences).collect(Collectors.toList()));
+        assertEquals(List.of(0, 1, 1, 1, 1, 2, 2, 2, 1, 1, 0),
+                result.stream().map(Block::getBlockLoopDepth).collect(Collectors.toList()));
     }
 }

--- a/src/test/java/edu/kit/compiler/register_allocation/LifetimeAnalysisTest.java
+++ b/src/test/java/edu/kit/compiler/register_allocation/LifetimeAnalysisTest.java
@@ -22,12 +22,14 @@ public class LifetimeAnalysisTest {
                 Instruction.newJmp("jl .L2", 2),
                 Instruction.newJmp("jmp .L3", 3)
         ), 1, 1);
+        loopHead.setBlockLoopDepth(1);
         Block loopBody = new Block(List.of(
                 Instruction.newOp("addl $1, @3", List.of(), Optional.of(1), 3),
                 Instruction.newOp("mov @3, @1", List.of(3), Optional.empty(), 1),
                 Instruction.newCall(List.of(1), Optional.empty(), "foo"),
                 Instruction.newJmp("jmp .L1", 1)
         ), 2, 0);
+        loopBody.setBlockLoopDepth(1);
         Block end = new Block(List.of(
                 Instruction.newOp("addl $7, @2", List.of(), Optional.of(0), 2),
                 Instruction.newRet(Optional.of(2))


### PR DESCRIPTION
Previously, the lifetime analysis assumed that for nested loops, the blocks are ordered in a way such that the blocks of the outer loop enclose the blocks of the inner loop, thus allowing the lifetime analysis to find loops based on the back jump at the end of the loop.

However, this ordering is not always possible anymore with the linear blocks optimization, because there might be e.g. a direct jump from the header of the inner loop to the header of the outer loop.

Therefore, I have changed the lifetime analysis to use loop depths instead, which are set by the analysis done for the block ordering (`ReversePostfixOrder`). Additionally, `ReversePostfixOrder` must now ensure that the loop depths are "flat", i.e. there can be no hole with lower depth in a loop, which could be created e.g. by a return within the loop.

Note that the ordering of the blocks is unchanged by this PR, the only visible change from outside is that the lifetime analysis can now determine the correct lifetimes in more (hopefully, all) cases.