### PR TITLE
fix: Correctly replace const calls

### DIFF
--- a/src/main/java/edu/kit/compiler/optimizations/PureFunctionOptimization.java
+++ b/src/main/java/edu/kit/compiler/optimizations/PureFunctionOptimization.java
@@ -45,9 +45,10 @@ public final class PureFunctionOptimization implements Optimization.Local {
         if (!node.getMem().equals(graph.getNoMem())) {
             // setting mem to NoMem on the original call would break the memory chain
             var constCall = (Call) graph.copyNode(node);
+            var projRes = graph.newProj(constCall, Mode.getT(), Call.pnTResult);
             constCall.setMem(graph.getNoMem());
 
-            exchangeCall(node, constCall, node.getMem());
+            exchangeCall(node, projRes, node.getMem());
             return true;
         } else {
             return false;

--- a/src/test/java/edu/kit/compiler/optimizations/PureFunctionOptimizationTest.java
+++ b/src/test/java/edu/kit/compiler/optimizations/PureFunctionOptimizationTest.java
@@ -83,6 +83,9 @@ public class PureFunctionOptimizationTest {
 
         var ret = (Return) Counter.getOnly(bar, ir_opcode.iro_Return);
         assertEquals(ret.getMem(), bar.getInitialMem());
+        assertEquals(ir_opcode.iro_Proj, ret.getPred(1).getOpCode());
+        assertEquals(ir_opcode.iro_Proj, ret.getPred(1).getPred(0).getOpCode());
+        assertEquals(ir_opcode.iro_Call, ret.getPred(1).getPred(0).getPred(0).getOpCode());
     }
 
     @Test


### PR DESCRIPTION
Previously, the tuples used to remove calls to constant functions would directly point to the call. This is wrong, as it omits the required projection to get the result tuple of the call.