### PR TITLE
Add assembly optimizations

### DIFF
--- a/src/main/java/edu/kit/compiler/JavaEasyCompiler.java
+++ b/src/main/java/edu/kit/compiler/JavaEasyCompiler.java
@@ -9,6 +9,7 @@ import edu.kit.compiler.assembly.AssemblyWriter;
 import edu.kit.compiler.assembly.ElfAssemblyWriter;
 import edu.kit.compiler.assembly.FunctionInstructions;
 import edu.kit.compiler.assembly.JumpInversion;
+import edu.kit.compiler.assembly.RemoveNop;
 import edu.kit.compiler.cli.Cli;
 import edu.kit.compiler.cli.CliOption;
 import edu.kit.compiler.cli.CliOptionGroup;
@@ -388,6 +389,7 @@ public class JavaEasyCompiler {
                 ), debugFlags);
                 allocator = new LinearScan();
                 asmOptimizer = new AssemblyOptimizer(List.of(
+                    new RemoveNop(),
                     new JumpInversion()
                 ));
                 break;

--- a/src/main/java/edu/kit/compiler/assembly/AssemblyOptimizer.java
+++ b/src/main/java/edu/kit/compiler/assembly/AssemblyOptimizer.java
@@ -1,0 +1,34 @@
+package edu.kit.compiler.assembly;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public final class AssemblyOptimizer {
+
+    private final Iterable<AssemblyOptimization> optimizations;
+
+    public List<String> apply(List<String> instructions) {
+        var result = new ArrayList<String>(instructions.size());
+        var optimized = getOptimizedInstructions(instructions);
+        optimized.forEachRemaining(result::add);
+
+        return result;
+    }
+
+    private Iterator<String> getOptimizedInstructions(List<String> instructions) {
+        var iterator = instructions.iterator();
+        for (var optimization : optimizations) {
+            iterator = optimization.optimize(iterator);
+        }
+
+        return iterator;
+    }
+
+    public interface AssemblyOptimization {
+        Iterator<String> optimize(Iterator<String> instructions);
+    }
+}

--- a/src/main/java/edu/kit/compiler/assembly/AssemblyOptimizer.java
+++ b/src/main/java/edu/kit/compiler/assembly/AssemblyOptimizer.java
@@ -6,6 +6,10 @@ import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * Represents a collection of assembly optimization that can be collectively
+ * applied to a list of instructions.
+ */
 @RequiredArgsConstructor
 public final class AssemblyOptimizer {
 
@@ -28,6 +32,9 @@ public final class AssemblyOptimizer {
         return iterator;
     }
 
+    /**
+     * Represents an optimization that can be applied to assembly instructions.
+     */
     public interface AssemblyOptimization {
         Iterator<String> optimize(Iterator<String> instructions);
     }

--- a/src/main/java/edu/kit/compiler/assembly/AssemblyOptimizer.java
+++ b/src/main/java/edu/kit/compiler/assembly/AssemblyOptimizer.java
@@ -16,7 +16,8 @@ import lombok.RequiredArgsConstructor;
 public final class AssemblyOptimizer {
 
     /**
-     * Represents an optimization that can be applied to assembly instructions.
+     * Represents an optimization that can be applied to a fixed size windows
+     * of assembly instructions.
      */
     @RequiredArgsConstructor
     public static abstract class AssemblyOptimization {
@@ -24,7 +25,13 @@ public final class AssemblyOptimizer {
         @Getter
         private final int windowSize;
 
-        abstract Optional<String[]> optimize(String[] instructions);
+        /**
+         * If possible, returns an optimized version of the given array of
+         * assembly instructions. Otherwise return nothing. The array can be
+         * relied upon to be of length `windowSize`. The array must not be
+         * modified, nor must it be contained in the returned Optional.
+         */
+        public abstract Optional<String[]> optimize(String[] instructions);
     }
 
     private final Iterable<AssemblyOptimization> optimizations;

--- a/src/main/java/edu/kit/compiler/assembly/AssemblyOptimizer.java
+++ b/src/main/java/edu/kit/compiler/assembly/AssemblyOptimizer.java
@@ -1,9 +1,11 @@
 package edu.kit.compiler.assembly;
 
-import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
+import java.util.Optional;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -13,29 +15,97 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public final class AssemblyOptimizer {
 
-    private final Iterable<AssemblyOptimization> optimizations;
-
-    public List<String> apply(List<String> instructions) {
-        var result = new ArrayList<String>(instructions.size());
-        var optimized = getOptimizedInstructions(instructions);
-        optimized.forEachRemaining(result::add);
-
-        return result;
-    }
-
-    private Iterator<String> getOptimizedInstructions(List<String> instructions) {
-        var iterator = instructions.iterator();
-        for (var optimization : optimizations) {
-            iterator = optimization.optimize(iterator);
-        }
-
-        return iterator;
-    }
-
     /**
      * Represents an optimization that can be applied to assembly instructions.
      */
-    public interface AssemblyOptimization {
-        Iterator<String> optimize(Iterator<String> instructions);
+    @RequiredArgsConstructor
+    public static abstract class AssemblyOptimization {
+
+        @Getter
+        private final int windowSize;
+
+        abstract Optional<String[]> optimize(String[] instructions);
+    }
+
+    private final Iterable<AssemblyOptimization> optimizations;
+
+    public List<String> apply(List<String> instructions) {
+        Deque<String> input = new ArrayDeque<>(instructions);
+
+        for (var optimization : optimizations) {
+            input = apply(input, optimization);
+        }
+
+        return List.copyOf(input);
+    }
+
+    private Deque<String> apply(Deque<String> input, AssemblyOptimization optimization) {
+        var windowSize = optimization.getWindowSize();
+
+        if (input.size() < windowSize) {
+            return input;
+        }
+
+        var output = new ArrayDeque<String>();
+        var window = new String[windowSize];
+
+        for (int i = 0; i < windowSize; ++i) {
+            window[i] = input.removeFirst();
+        }
+
+        do {
+            var optimized = optimization.optimize(window);
+            if (optimized.isPresent()) {
+                copyWindow(optimized.get(), window, input);
+            } else {
+                advanceWindow(window, input, output);
+            }
+
+        } while (!input.isEmpty());
+
+        for (var instr : window) {
+            if (instr != null) {
+                output.addLast(instr);
+            }
+        }
+
+        return output;
+    }
+
+    /**
+     * Shift the window left by one position. Left margin is pushed to output,
+     * right margin ist popped from output.
+     */
+    private void advanceWindow(String[] window, Deque<String> input, Deque<String> output) {
+        assert window.length > 0;
+
+        output.addLast(window[0]);
+        for (int i = 1; i < window.length; ++i) {
+            window[i - 1] = window[i];
+        }
+
+        if (!input.isEmpty()) {
+            window[window.length - 1] = input.removeFirst();
+        }
+    }
+
+    /**
+     * Copy element from `source` to `target`. Spare element are pushed and
+     * popped from the front of `instructions`
+     */
+    private void copyWindow(String[] source, String[] target, Deque<String> instructions) {
+        var min = Math.min(source.length, target.length);
+
+        for (int i = 0; i < min; ++i) {
+            target[i] = source[i];
+        }
+
+        for (int i = source.length; i < target.length && !instructions.isEmpty(); ++i) {
+            target[i] = instructions.removeFirst();
+        }
+
+        for (int i = target.length; i < source.length; ++i) {
+            instructions.addFirst(source[i]);
+        }
     }
 }

--- a/src/main/java/edu/kit/compiler/assembly/AssemblyOptimizer.java
+++ b/src/main/java/edu/kit/compiler/assembly/AssemblyOptimizer.java
@@ -104,7 +104,7 @@ public final class AssemblyOptimizer {
             target[i] = instructions.removeFirst();
         }
 
-        for (int i = target.length; i < source.length; ++i) {
+        for (int i = source.length - 1; i >= target.length ; --i) {
             instructions.addFirst(source[i]);
         }
     }

--- a/src/main/java/edu/kit/compiler/assembly/JumpInversion.java
+++ b/src/main/java/edu/kit/compiler/assembly/JumpInversion.java
@@ -1,0 +1,160 @@
+package edu.kit.compiler.assembly;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import edu.kit.compiler.io.BufferedLookaheadIterator;
+import edu.kit.compiler.io.LookaheadIterator;
+import lombok.Getter;
+
+public final class JumpInversion implements Iterator<String> {
+
+    private final LookaheadIterator<String> input;
+
+    public JumpInversion(FunctionInstructions function) {
+        this.input = new BufferedLookaheadIterator<>(
+                function.getInstructions().iterator());
+    }
+
+    @Override
+    public boolean hasNext() {
+        return input.has();
+    }
+
+    @Override
+    public String next() {
+        if (input.has(2)) {
+            return parseConditional();
+        } else {
+            return input.getNext();
+        }
+    }
+
+    private String parseConditional() {
+        assert input.has(0);
+
+        var instruction = input.get(0);
+        var space = instruction.indexOf(' ');
+
+        if (space != -1) {
+            return Jump.get(instruction.substring(0, space))
+                    .map(jump -> {
+                        var trueLabel = instruction.substring(space).stripLeading();
+                        return parseUnconditional(jump, trueLabel);
+                    })
+                    .orElseGet(input::getNext);
+        } else {
+            return input.getNext();
+        }
+    }
+
+    private String parseUnconditional(Jump trueJump, String trueLabel) {
+        assert input.has(1);
+
+        var instruction = input.get(1);
+
+        if (instruction.startsWith("jmp ")) {
+            var falseLabel = instruction.substring(3).stripLeading();
+            return parseLabel(trueJump, trueLabel, falseLabel);
+        } else {
+            return input.getNext();
+        }
+    }
+
+    private String parseLabel(Jump trueJump, String trueLabel, String falseLabel) {
+        assert input.has(2);
+
+        var instruction = input.get(2);
+        if (instruction.startsWith(trueLabel) && instruction.endsWith(":")) {
+            input.next(2);
+            return trueJump.getInverse().getInstruction() + " " + falseLabel;
+        } else {
+            return input.getNext();
+        }
+    }
+
+    private enum Jump {
+        JO,
+        JNO,
+        JS,
+        JNS,
+        JE,
+        JZ,
+        JNE,
+        JNZ,
+        JB,
+        JNAE,
+        JC,
+        JNB,
+        JAE,
+        JNC,
+        JBE,
+        JNA,
+        JA,
+        JNBE,
+        JL,
+        JNGE,
+        JGE,
+        JNL,
+        JLE,
+        JNG,
+        JG,
+        JNLE,
+        JP,
+        JPE,
+        JNP,
+        JPO;
+
+        @Getter
+        private final String instruction;
+
+        private Jump() {
+            this.instruction = this.name().toLowerCase();
+        }
+
+        public static Optional<Jump> get(String instruction) {
+            return Optional.ofNullable(JUMPS.get(instruction));
+        }
+
+        private static final Map<String, Jump> JUMPS = Arrays.stream(Jump.values())
+                .collect(Collectors.toMap(Jump::getInstruction, x -> x));
+
+        public Jump getInverse() {
+            return switch (this) {
+                case JO -> JNO;
+                case JNO -> JO;
+                case JS -> JNS;
+                case JNS -> JS;
+                case JE -> JNE;
+                case JNE -> JE;
+                case JZ -> JNZ;
+                case JNZ -> JZ;
+                case JB -> JNB;
+                case JNB -> JB;
+                case JNAE -> JAE;
+                case JAE -> JNAE;
+                case JC -> JNC;
+                case JNC -> JC;
+                case JBE -> JNBE;
+                case JNBE -> JBE;
+                case JNA -> JA;
+                case JA -> JNA;
+                case JL -> JNL;
+                case JNL -> JL;
+                case JNGE -> JGE;
+                case JGE -> JNGE;
+                case JLE -> JNLE;
+                case JNLE -> JLE;
+                case JNG -> JG;
+                case JG -> JNG;
+                case JP -> JNP;
+                case JNP -> JP;
+                case JPE -> JPO;
+                case JPO -> JPE;
+            };
+        }
+    }
+}

--- a/src/main/java/edu/kit/compiler/assembly/JumpInversion.java
+++ b/src/main/java/edu/kit/compiler/assembly/JumpInversion.java
@@ -12,6 +12,11 @@ import edu.kit.compiler.io.LookaheadIterator;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * An optimization to improve control flow in assembly. A conditional jump
+ * to Label A, followed by an unconditional jump to label B is replaced with
+ * a single conditional jump to label B if fallthrough is possible.
+ */
 public final class JumpInversion implements AssemblyOptimization {
 
     @Override

--- a/src/main/java/edu/kit/compiler/assembly/JumpInversion.java
+++ b/src/main/java/edu/kit/compiler/assembly/JumpInversion.java
@@ -20,7 +20,7 @@ public final class JumpInversion extends AssemblyOptimization {
     }
 
     @Override
-    Optional<String[]> optimize(String[] instructions) {
+    public Optional<String[]> optimize(String[] instructions) {
         var trueJump = Jump.parse(instructions[0]);
         if (trueJump.isEmpty()) {
             return Optional.empty();

--- a/src/main/java/edu/kit/compiler/assembly/RemoveNop.java
+++ b/src/main/java/edu/kit/compiler/assembly/RemoveNop.java
@@ -15,7 +15,7 @@ public class RemoveNop extends AssemblyOptimization {
     }
 
     @Override
-    Optional<String[]> optimize(String[] instructions) {
+    public Optional<String[]> optimize(String[] instructions) {
         if (instructions[0] == "nop") {
             return Optional.of(new String[0]);
         } else {

--- a/src/main/java/edu/kit/compiler/assembly/RemoveNop.java
+++ b/src/main/java/edu/kit/compiler/assembly/RemoveNop.java
@@ -1,0 +1,52 @@
+package edu.kit.compiler.assembly;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import edu.kit.compiler.assembly.AssemblyOptimizer.AssemblyOptimization;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * A basic optimization to remove `nop` instructions, potentially introduced
+ * by Unknown nodes in the Firm graph.
+ */
+public class RemoveNop implements AssemblyOptimization {
+
+    @Override
+    public Iterator<String> optimize(Iterator<String> instructions) {
+        return new Optimization(instructions);
+    }
+
+    @RequiredArgsConstructor
+    private static final class Optimization implements Iterator<String> {
+
+        private final Iterator<String> input;
+
+        private String buffer;
+
+        @Override
+        public boolean hasNext() {
+            fillBuffer();
+            return buffer != null;
+        }
+
+        @Override
+        public String next() {
+            var next = buffer;
+            buffer = null;
+
+            if (next != null) {
+                return next;
+            } else {
+                throw new NoSuchElementException();
+            }
+        }
+
+        private void fillBuffer() {
+            while (buffer == null && input.hasNext()) {
+                var next = input.next();
+                buffer = next == "nop" ? null : next;
+            }
+        }
+    }
+}

--- a/src/main/java/edu/kit/compiler/assembly/RemoveNop.java
+++ b/src/main/java/edu/kit/compiler/assembly/RemoveNop.java
@@ -1,52 +1,25 @@
 package edu.kit.compiler.assembly;
 
-import java.util.Iterator;
-import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import edu.kit.compiler.assembly.AssemblyOptimizer.AssemblyOptimization;
-import lombok.RequiredArgsConstructor;
 
 /**
  * A basic optimization to remove `nop` instructions, potentially introduced
  * by Unknown nodes in the Firm graph.
  */
-public class RemoveNop implements AssemblyOptimization {
+public class RemoveNop extends AssemblyOptimization {
 
-    @Override
-    public Iterator<String> optimize(Iterator<String> instructions) {
-        return new Optimization(instructions);
+    public RemoveNop() {
+        super(1);
     }
 
-    @RequiredArgsConstructor
-    private static final class Optimization implements Iterator<String> {
-
-        private final Iterator<String> input;
-
-        private String buffer;
-
-        @Override
-        public boolean hasNext() {
-            fillBuffer();
-            return buffer != null;
-        }
-
-        @Override
-        public String next() {
-            var next = buffer;
-            buffer = null;
-
-            if (next != null) {
-                return next;
-            } else {
-                throw new NoSuchElementException();
-            }
-        }
-
-        private void fillBuffer() {
-            while (buffer == null && input.hasNext()) {
-                var next = input.next();
-                buffer = next == "nop" ? null : next;
-            }
+    @Override
+    Optional<String[]> optimize(String[] instructions) {
+        if (instructions[0] == "nop") {
+            return Optional.of(new String[0]);
+        } else {
+            return Optional.empty();
         }
     }
 }

--- a/src/main/java/edu/kit/compiler/io/LookaheadIterator.java
+++ b/src/main/java/edu/kit/compiler/io/LookaheadIterator.java
@@ -36,4 +36,5 @@ public interface LookaheadIterator<T> {
      * Move the lookahead iterator forward for the given number of steps.
      */
     void next(int steps);
+
 }

--- a/src/main/java/edu/kit/compiler/io/LookaheadIterator.java
+++ b/src/main/java/edu/kit/compiler/io/LookaheadIterator.java
@@ -37,4 +37,12 @@ public interface LookaheadIterator<T> {
      */
     void next(int steps);
 
+    /**
+     * Return the next element and advance the iterator.
+     */
+    default T getNext() {
+        var result = get();
+        next();
+        return result;
+    }
 }

--- a/src/main/java/edu/kit/compiler/io/LookaheadIterator.java
+++ b/src/main/java/edu/kit/compiler/io/LookaheadIterator.java
@@ -36,13 +36,4 @@ public interface LookaheadIterator<T> {
      * Move the lookahead iterator forward for the given number of steps.
      */
     void next(int steps);
-
-    /**
-     * Return the next element and advance the iterator.
-     */
-    default T getNext() {
-        var result = get();
-        next();
-        return result;
-    }
 }

--- a/src/test/java/edu/kit/compiler/assembly/JumpInversionTest.java
+++ b/src/test/java/edu/kit/compiler/assembly/JumpInversionTest.java
@@ -1,0 +1,58 @@
+package edu.kit.compiler.assembly;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class JumpInversionTest {
+
+    private JumpInversion optimization;
+
+    @BeforeEach
+    public void setup() {
+        optimization = new JumpInversion();
+    }
+
+    @Test
+    public void testReplaceJNZ() {
+        var res = optimize("jnz .L1", "jmp .L2", ".L1:");
+        assertEquals(List.of("jz .L2", ".L1:"), res);
+    }
+
+    @Test
+    public void testReplaceJG() {
+        var res = optimize("jg .L1", "jmp .L2", ".L1:");
+        assertEquals(List.of("jng .L2", ".L1:"), res);
+    }
+
+    @Test
+    public void testNoDefaultJump() {
+        var res = optimize("jnz .L2", ".L1");
+        assertEquals(List.of("jnz .L2", ".L1"), res);
+    }
+
+    @Test
+    public void testNoCondJump() {
+        var res = optimize("addl %rax, %rbx", "jump .L2", ".L1");
+        assertEquals(List.of("addl %rax, %rbx", "jump .L2", ".L1"), res);
+    }
+
+    @Test
+    public void testNoLabel() {
+        var res = optimize("jnz .L1", "jmp .L2", "addl %rax, %rbx");
+        assertEquals(List.of("jnz .L1", "jmp .L2", "addl %rax, %rbx"), res);
+    }
+
+    private List<String> optimize(String... instructions) {
+        var input = Arrays.stream(instructions).iterator();
+        var output = optimization.optimize(input);
+        var result = new ArrayList<String>();
+        output.forEachRemaining(result::add);
+        return result;
+    }
+}


### PR DESCRIPTION
This PR introduces a basic framework for assembly optimizations and uses it to implement the following two optimizations.

1. Jump Inversion (I don't know if that is the correct name) uses fall-through to optimize conditional jumps followed by unconditional ones where possible. For example, the following list of instruction
    ```asm
    jnz .L1
    jmp .L2
    .L1:
    ```
    is simplified to
    ```asm
    jz .L2
    .L1:
    ```

2. Remove all `nop`s, which may have been introduced to deal with `Unknown` nodes during instruction selection.