### PR TITLE
Minor register allocation improvements

### DIFF
--- a/mjtest-files/compile/Knapsack.mj
+++ b/mjtest-files/compile/Knapsack.mj
@@ -1,0 +1,121 @@
+/* A brute-force knapsack solver (that outputs the optimum value). */
+class Knapsack {
+    public int n;
+    public int maxWeight;
+    public int[] weights;
+    public int[] values;
+    public int[] numAvailable;
+
+    public static void main(String[] args) {
+        Knapsack knapsack = new Knapsack();
+        knapsack.init();
+        System.out.println(knapsack.solve());
+    }
+
+    public void init() {
+        this.n = 12;
+        this.maxWeight = 114;
+        this.weights = new int[n];
+        this.values = new int[n];
+        this.numAvailable = new int[n];
+        weights[0] = 3;
+        values[0] = 4;
+        numAvailable[0] = 7;
+        weights[1] = 1;
+        values[1] = 1;
+        numAvailable[1] = 6;
+        weights[2] = 4;
+        values[2] = 6;
+        numAvailable[2] = 3;
+        weights[3] = 2;
+        values[3] = 2;
+        numAvailable[3] = 4;
+        weights[4] = 7;
+        values[4] = 11;
+        numAvailable[4] = 3;
+        weights[5] = 6;
+        values[5] = 7;
+        numAvailable[5] = 5;
+        weights[6] = 10;
+        values[6] = 11;
+        numAvailable[6] = 4;
+        weights[7] = 3;
+        values[7] = 5;
+        numAvailable[7] = 4;
+        weights[8] = 17;
+        values[8] = 21;
+        numAvailable[8] = 4;
+        weights[9] = 6;
+        values[9] = 11;
+        numAvailable[9] = 2;
+        weights[10] = 3;
+        values[10] = 4;
+        numAvailable[10] = 8;
+        weights[11] = 7;
+        values[11] = 9;
+        numAvailable[11] = 2;
+    }
+
+    public int solve() {
+        if (n == 0) {
+            return 0;
+        }
+        if (n % 2 == 0) {
+            return solveForPosition(0, weights[0], values[0], numAvailable[0],
+                                       weights[1], values[1], numAvailable[1],
+                                       maxWeight, 0);
+        } else {
+            return solveForPosition(0, 0, 0, 0,
+                                       weights[0], values[0], numAvailable[0],
+                                       maxWeight, 0);
+        }
+    }
+
+    public int solveForPosition(int i, int weight1, int val1, int available1, int weight2, int val2, int available2,
+                                int remainingWeight, int prevVal) {
+        if (i + 2 == n) {
+            int max = 0;
+            int n1 = 0;
+            while (n1 <= available1) {
+                int n2 = 0;
+                while (n2 <= available2) {
+                    if (n1 * weight1 + n2 * weight2 <= remainingWeight) {
+                        int val = n1 * val1 + n2 * val2;
+                        if (val > max) {
+                            max = val;
+                        }
+                    }
+                    n2 = n2 + 1;
+                }
+                n1 = n1 + 1;
+            }
+            return prevVal + max;
+        } else {
+            int max = 0;
+            int n1 = 0;
+            int w2 = weights[i+2];
+            int w3 = weights[i+3];
+            int v2 = values[i+2];
+            int v3 = values[i+3];
+            int a2 = numAvailable[i+2];
+            int a3 = numAvailable[i+3];
+            while (n1 <= available1) {
+                int n2 = 0;
+                while (n2 <= available2) {
+                    int nextWeight = remainingWeight - n1 * weight1 - n2 * weight2;
+                    if (nextWeight >= 0) {
+                        int nextVal = n1 * val1 + n2 * val2;
+                        int val = solveForPosition(i + 2, w2, v2, a2, w3, v3, a3, nextWeight, nextVal);
+                        if (val > max) {
+                            max = val;
+                        }
+                    }
+                    n2 = n2 + 1;
+                }
+                n1 = n1 + 1;
+            }
+            return prevVal + max;
+        }
+    }
+}
+

--- a/mjtest-files/compile/StackSlots.mj
+++ b/mjtest-files/compile/StackSlots.mj
@@ -1,0 +1,45 @@
+class StackSlots {
+    public static void main(String[] args) {
+        StackSlots obj = new StackSlots();
+        obj.recurseAndPrint(4, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+
+    public void recurseAndPrint(int recDepth, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10) {
+        if (recDepth == 0) {
+            return;
+        }
+
+        int i = 0;
+        while (i < 2) {
+            i = i + 1;
+            int var1 = arg3;
+            int var2 = arg4;
+            int var3 = arg5;
+            int var4 = arg6;
+            int var5 = var1 + var2;
+            int var6 = var3 + var4;
+            int tmp = arg3;
+            arg3 = arg4;
+            arg4 = arg5;
+            arg5 = arg6;
+            arg6 = tmp;
+            var1 = var1 - arg6;
+            var2 = var2 - arg5;
+            var3 = var3 - arg4;
+            var4 = var4 - arg3;
+            var5 = var5 - var1;
+            var6 = var6 - var5;
+            recurseAndPrint(recDepth - 1, arg3, arg4, arg5, arg6, 7, 8, 9, 10);
+            System.out.println(var1);
+            System.out.println(var2);
+            System.out.println(var3);
+            System.out.println(var4);
+            System.out.println(var5);
+            System.out.println(var6);
+        }
+        System.out.println(arg7);
+        System.out.println(arg8);
+        System.out.println(arg9);
+        System.out.println(arg10);
+    }
+}

--- a/src/main/java/edu/kit/compiler/register_allocation/ApplyAssignment.java
+++ b/src/main/java/edu/kit/compiler/register_allocation/ApplyAssignment.java
@@ -2,6 +2,7 @@ package edu.kit.compiler.register_allocation;
 
 import edu.kit.compiler.codegen.PermutationSolver;
 import edu.kit.compiler.intermediate_lang.*;
+import edu.kit.compiler.transform.StandardLibraryEntities;
 import lombok.Getter;
 
 import java.util.*;
@@ -367,7 +368,8 @@ public class ApplyAssignment {
 
         // align to 16 byte (only required for external functions, which take all args in registers)
         int alignmentOffset = 0;
-        if (numArgsOnStack == 0 && (savedOffset % 16 != 0)) {
+        if (StandardLibraryEntities.INSTANCE.isStandardLibraryEntity(instr.getCallReference().get())
+                && (savedOffset % 16 != 0)) {
             alignmentOffset = 8;
             output("subq $8, %rsp # align stack to 16 byte");
         }

--- a/src/main/java/edu/kit/compiler/register_allocation/ApplyAssignment.java
+++ b/src/main/java/edu/kit/compiler/register_allocation/ApplyAssignment.java
@@ -532,6 +532,10 @@ public class ApplyAssignment {
         return result;
     }
 
+    public static int argOffsetOnStack(int nArgs, int vRegister) {
+        return 16 + 8 * (nArgs - vRegister - 1);
+    }
+
     private int countRequiredTmps(LifetimeTracker tracker, Instruction instr, int index) {
         assert instr.getType() == InstructionType.GENERAL;
         int n = 0;
@@ -646,10 +650,6 @@ public class ApplyAssignment {
         stackSize = stackSize - (stackSize % 8);
         assert stackSize >= sizeOld && stackSize <= sizeOld + 8 && stackSize % 8 == 0;
         return stackSize;
-    }
-
-    private static int argOffsetOnStack(int nArgs, int vRegister) {
-        return 16 + 8 * (nArgs - vRegister - 1);
     }
 
     private void output(String instr) {

--- a/src/main/java/edu/kit/compiler/register_allocation/LinearScan.java
+++ b/src/main/java/edu/kit/compiler/register_allocation/LinearScan.java
@@ -227,6 +227,8 @@ public class LinearScan implements RegisterAllocator {
  * Also handles register assignments and spilling.
  */
 class ScanState {
+    private static final CallingConvention CCONV = CallingConvention.X86_64;
+
     @Getter
     private LifetimeAnalysis analysis;
     @Getter
@@ -423,7 +425,7 @@ class ScanState {
                     stackSlots.getSlot(overwrite.get()).ifPresent(preference::add);
                 }
             }
-        } else {
+        } else if (!CCONV.isPassedInRegister(vRegister)) {
             // argument
             assert analysis.getLifetime(vRegister).getBegin() < 0;
             preference.add(new SlotAssignment(ApplyAssignment.argOffsetOnStack(nArgs, vRegister), true));

--- a/src/main/java/edu/kit/compiler/register_allocation/LinearScan.java
+++ b/src/main/java/edu/kit/compiler/register_allocation/LinearScan.java
@@ -364,14 +364,18 @@ class ScanState {
         int best = -1;
         int bestLoopDepth = Integer.MAX_VALUE;
         int bestLifetimeEnd = -1;
+        int bestNumUses = Integer.MAX_VALUE;
         for (int r: vRegisters) {
             int loopDepth = analysis.getLoopDepth(r);
             int lifetimeEnd = analysis.getLifetime(r).getEnd();
+            int numUses = analysis.getNumUses(r);
             if (loopDepth < bestLoopDepth ||
-                    (loopDepth == bestLoopDepth && lifetimeEnd > bestLifetimeEnd)) {
+                    (loopDepth == bestLoopDepth && lifetimeEnd > bestLifetimeEnd) ||
+                    (loopDepth == bestLoopDepth && lifetimeEnd == bestLifetimeEnd && numUses < bestNumUses)) {
                 best = r;
                 bestLoopDepth = loopDepth;
                 bestLifetimeEnd = lifetimeEnd;
+                bestNumUses = numUses;
             }
         }
         return best;

--- a/src/main/java/edu/kit/compiler/transform/StandardLibraryEntities.java
+++ b/src/main/java/edu/kit/compiler/transform/StandardLibraryEntities.java
@@ -11,6 +11,8 @@ import firm.Type;
 import firm.bindings.binding_typerep.ir_visibility;
 import lombok.Getter;
 
+import java.util.Set;
+
 /**
  * A Singleton holding reference to the standard library methods.
  * Each method is a Entity in the global type of the program.
@@ -28,6 +30,7 @@ public enum StandardLibraryEntities {
     private final TypedEntity<MethodType> flush;
     @Getter
     private final TypedEntity<MethodType> calloc;
+    private final Set<String> entityNames;
 
     /**
      * Return the corresponding entity for the given standard library method. This
@@ -83,5 +86,17 @@ public enum StandardLibraryEntities {
         write.getEntity().setVisibility(ir_visibility.ir_visibility_external);
         flush.getEntity().setVisibility(ir_visibility.ir_visibility_external);
         calloc.getEntity().setVisibility(ir_visibility.ir_visibility_external);
+
+        this.entityNames = Set.of(
+                read.getEntity().getLdName(),
+                print.getEntity().getLdName(),
+                write.getEntity().getLdName(),
+                flush.getEntity().getLdName(),
+                calloc.getEntity().getLdName()
+        );
+    }
+
+    public boolean isStandardLibraryEntity(String functionName) {
+        return entityNames.contains(functionName);
     }
 }


### PR DESCRIPTION
Adds two minor improvements to the register allocator:
- The allocator now only aligns the stack pointer to 16 byte if the call is a standard library call
- When spilling a register, the allocator is now able to reuse stack slots and also able to use the stack slot of a stack-passed argument. Further, the PR adds a small refinement to the heuristic for selecting the spilled register.

(Note: The second improvement applies quite seldomly, as we are rarely spilling registers anyway.)