### PR TITLE
Add loop invariant optimization

### DIFF
--- a/src/main/java/edu/kit/compiler/JavaEasyCompiler.java
+++ b/src/main/java/edu/kit/compiler/JavaEasyCompiler.java
@@ -35,6 +35,7 @@ import edu.kit.compiler.optimizations.ArithmeticIdentitiesOptimization;
 import edu.kit.compiler.optimizations.ArithmeticReplacementOptimization;
 import edu.kit.compiler.optimizations.ConstantOptimization;
 import edu.kit.compiler.optimizations.LinearBlocksOptimization;
+import edu.kit.compiler.optimizations.LoopInvariantOptimization;
 import edu.kit.compiler.optimizations.Optimizer;
 import edu.kit.compiler.optimizations.PureFunctionOptimization;
 import edu.kit.compiler.parser.Parser;
@@ -378,7 +379,8 @@ public class JavaEasyCompiler {
                     new ArithmeticReplacementOptimization(),
                     new LinearBlocksOptimization(),
                     new InliningOptimization(),
-                    new PureFunctionOptimization()
+                    new PureFunctionOptimization(),
+                    new LoopInvariantOptimization()
                 ), debugFlags);
                 allocator = new LinearScan();
                 break;

--- a/src/main/java/edu/kit/compiler/optimizations/LoopInvariantOptimization.java
+++ b/src/main/java/edu/kit/compiler/optimizations/LoopInvariantOptimization.java
@@ -17,7 +17,8 @@ import firm.nodes.Node;
  * loop entry point. Nodes invariant to inner blocks are moved as far out as
  * possible.
  * 
- * Control flow, memory and Phi nodes are not affected.
+ * This analysis respects the pin state of nodes. In addition, control flow and
+ * Phi nodes are never moved.
  */
 public class LoopInvariantOptimization implements Optimization.Local {
 

--- a/src/main/java/edu/kit/compiler/optimizations/LoopInvariantOptimization.java
+++ b/src/main/java/edu/kit/compiler/optimizations/LoopInvariantOptimization.java
@@ -1,0 +1,57 @@
+package edu.kit.compiler.optimizations;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import edu.kit.compiler.io.CommonUtil;
+import edu.kit.compiler.optimizations.analysis.LoopInvariantAnalysis;
+
+import firm.Graph;
+import firm.nodes.Block;
+import firm.nodes.Node;
+
+/**
+ * Optimization that moves loop-invariant nodes in front of the loop. Invariant
+ * nodes are moved to the deepest common dominator of the predecessors of the
+ * loop entry point. Nodes invariant to inner blocks are moved as far out as
+ * possible.
+ * 
+ * Control flow, memory and Phi nodes are not affected.
+ */
+public class LoopInvariantOptimization implements Optimization.Local {
+
+    @Override
+    public boolean optimize(Graph graph, OptimizationState state) {
+        LoopInvariantAnalysis loopInvariantAnalysis = new LoopInvariantAnalysis(graph);
+        loopInvariantAnalysis.analyze();
+
+        Map<Block, Set<Node>> loopInvariantNodes = loopInvariantAnalysis.getLoopInvariantNodes();
+
+        boolean change = false;
+        for (Map.Entry<Block, Set<Block>> loop : loopInvariantAnalysis.getLoops().entrySet()) {
+            Block loopEntryPoint = loop.getKey();
+            Set<Block> loopBlocks = loop.getValue();
+
+            Iterable<Block> loopHeaderPredecessors = CommonUtil.stream(loopEntryPoint.getPreds())
+                .map(node -> (Block) node.getBlock())
+                .collect(Collectors.toList());
+            Block targetBlock = Util.findDeepestCommonDominator(loopHeaderPredecessors);
+
+            if (targetBlock == null) {
+                // loop header has no predecessors
+                continue;
+            }
+
+            for (Node node : loopInvariantNodes.get(loopEntryPoint)) {
+                if (loopBlocks.contains(node.getBlock())) {
+                    node.setBlock(targetBlock);
+                    change = true;
+                }
+            }
+        }
+
+        return change;
+    }
+
+}

--- a/src/main/java/edu/kit/compiler/optimizations/analysis/LoopAnalysis.java
+++ b/src/main/java/edu/kit/compiler/optimizations/analysis/LoopAnalysis.java
@@ -1,0 +1,158 @@
+package edu.kit.compiler.optimizations.analysis;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import edu.kit.compiler.optimizations.Util.BlockSuccessorMapper;
+
+import firm.Graph;
+import firm.nodes.Block;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Analysis that finds all loops in a graph. Loops consist of a loop entry
+ * point (not necessarily the loop header) and loop blocks (including the loop
+ * entry point). If a loop contains another loop, then the loop blocks of the
+ * outer loop will also contain the loop blocks of the inner loop.
+ * 
+ * In addition, a mapping from blocks to the loops in which they are contained
+ * is computed.
+ */
+@RequiredArgsConstructor
+public class LoopAnalysis {
+
+    private final Graph graph;
+
+    /**
+     * All loops in the graph.
+     * 
+     * The loop entry point is the map key, while the loop blocks are the
+     * value.
+     */
+    @Getter
+    private Map<Block, Set<Block>> loops = new HashMap<>();
+    /**
+     * Map with all loops in which the key block is contained.
+     */
+    @Getter
+    private Map<Block, Set<Block>> blockLoops = new HashMap<>();
+
+    private Map<Block, Set<Block>> successors = new HashMap<>();
+
+    private Set<Block> visited = new HashSet<>();
+    private Set<Block> active = new HashSet<>();
+
+    /**
+     * Analyze the given graph to find loops.
+     */
+    public void analyze() {
+        BlockSuccessorMapper blockSuccessorMapper = new BlockSuccessorMapper(successors);
+        graph.walkBlocksPostorder(blockSuccessorMapper);
+
+        dfs(graph.getStartBlock());
+    }
+
+    /**
+     * Depth-first seach though the blocks of a graph. The blocks are traversed
+     * in control flow order, i.e. from start to end.
+     */
+    private Set<Block> dfs(Block block) {
+        if (isActive(block)) {
+            // loop (re-)discovered
+            loops.computeIfAbsent(block, item -> new HashSet<>()).add(block);
+            blockLoops.get(block).add(block);
+
+            // return this as active loop
+            return Set.of(block);
+        } else if (isVisited(block)) {
+            // continue loop
+            return blockLoops.get(block);
+        }
+
+        // initialize block
+        blockLoops.put(block, new HashSet<>());
+
+        markActive(block);
+
+        // find directly surrounding loops
+        Set<Block> directLoops = new HashSet<>();
+        for (Block succ : successors.get(block)) {
+            directLoops.addAll(dfs(succ));
+        }
+
+        markInactive(block);
+
+        // loop ends when moving from the loop entry point to its predecessor
+        directLoops.remove(block);
+
+        Set<Block> loopBlocks;
+        if (loops.containsKey(block)) {
+            // if this block is the loop entry point, propagate loops blocks to
+            // outer surrounding loops
+            loopBlocks = loops.get(block);
+        } else {
+            // else only add this block to its directly surrounding loops
+            loopBlocks = Set.of(block);
+        }
+
+        // update block loops with directly surrounding loops
+        for (Block loopBlock : loopBlocks) {
+            blockLoops.get(loopBlock).addAll(directLoops);
+        }
+
+        // add blocks to directly surrounding loops
+        for (Block directLoop : directLoops) {
+            loops.get(directLoop).addAll(loopBlocks);
+        }
+
+        markVisited(block);
+
+        // return directly surrounding loops to predecessors
+        return directLoops;
+    }
+
+    /**
+     * If the given block was visited before. This includes that the edges to
+     * all its successors were followed.
+     */
+    private boolean isVisited(Block block) {
+        return visited.contains(block);
+    }
+
+    /**
+     * Mark the given block as visited. This includes that the edges to all its
+     * successors were followed.
+     */
+    private void markVisited(Block block) {
+        visited.add(block);
+    }
+
+    /**
+     * If the given block is active. A block is active if at least one incoming
+     * edge, but not all outgoing edges were followed.
+     */
+    private boolean isActive(Block block) {
+        return active.contains(block);
+    }
+
+    /**
+     * Mark the given block as active. A block is active if at least one
+     * incoming edge, but not all outgoing edges were followed.
+     */
+    private void markActive(Block block) {
+        active.add(block);
+    }
+
+    /**
+     * Mark the given block as inactive. A block is active if at least one
+     * incoming edge, but not all outgoing edges were followed.
+     */
+    private void markInactive(Block block) {
+        active.remove(block);
+    }
+
+}

--- a/src/main/java/edu/kit/compiler/optimizations/analysis/LoopAnalysis.java
+++ b/src/main/java/edu/kit/compiler/optimizations/analysis/LoopAnalysis.java
@@ -69,8 +69,10 @@ public class LoopAnalysis {
             // return this as active loop
             return Set.of(block);
         } else if (isVisited(block)) {
-            // continue loop
-            return blockLoops.get(block);
+            // continue loop if inside
+            Set<Block> activeLoops = new HashSet<>(blockLoops.get(block));
+            activeLoops.remove(block);
+            return activeLoops;
         }
 
         // initialize block

--- a/src/main/java/edu/kit/compiler/optimizations/analysis/LoopInvariantAnalysis.java
+++ b/src/main/java/edu/kit/compiler/optimizations/analysis/LoopInvariantAnalysis.java
@@ -1,0 +1,96 @@
+package edu.kit.compiler.optimizations.analysis;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import edu.kit.compiler.io.CommonUtil;
+import edu.kit.compiler.optimizations.Util.NodeListFiller;
+
+import firm.Graph;
+import firm.nodes.Block;
+import firm.nodes.Node;
+import firm.nodes.Phi;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Analysis that finds all loop-invariant nodes in a graph. The result is
+ * provided as a map from loop entry points (see LoopAnalysis) to the nodes
+ * invariant to the representing loop. A node can be invariant to multiple
+ * loops.
+ * 
+ * Control flow, memory and Phi nodes are never marked as invariant.
+ */
+@RequiredArgsConstructor
+public class LoopInvariantAnalysis {
+
+    private final Graph graph;
+
+    /**
+     * Loops in the graph as received from LoopAnalysis.
+     */
+    @Getter
+    private Map<Block, Set<Block>> loops;
+    /**
+     * Map from loop entry point to nodes invariant to the represented loop. A
+     * node can be invariant to multiple loops.
+     */
+    @Getter
+    private Map<Block, Set<Node>> loopInvariantNodes;
+
+    /**
+     * Analyze the given graph to find loop-invariant nodes.
+     */
+    public void analyze() {
+        // the nodes are visited in postorder such that invariant predecessors
+        // are already found when visiting a node
+        List<Node> nodes = new ArrayList<>();
+        graph.walkPostorder(new NodeListFiller(nodes));
+
+        LoopAnalysis loopAnalysis = new LoopAnalysis(graph);
+        loopAnalysis.analyze();
+
+        loops = loopAnalysis.getLoops();
+        loopInvariantNodes = new HashMap<>();
+
+        for (Map.Entry<Block, Set<Block>> loop : loops.entrySet()) {
+            Block loopEntryPoint = loop.getKey();
+            Set<Block> loopBlocks = loop.getValue();
+
+            Set<Node> invariantNodes = new HashSet<>();
+            nodes.stream().filter(item -> loopBlocks.contains(item.getBlock())).forEach(node -> {
+                if (isLoopInvariant(node, loopBlocks, invariantNodes)) {
+                    invariantNodes.add(node);
+                }
+            });
+
+            loopInvariantNodes.put(loopEntryPoint, invariantNodes);
+        }
+    }
+
+    /**
+     * Whether a given node is invariant to the loop containing the given loop
+     * blocks given a set of nodes invariant to that loop.
+     */
+    public boolean isLoopInvariant(Node node, Set<Block> loopBlocks, Set<Node> loopInvariantNodes) {
+        if (node instanceof Phi) {
+            return false;
+        }
+
+        if (!node.getMode().isData()) {
+            return false;
+        }
+
+        return CommonUtil.stream(node.getPreds())
+            .allMatch(pred ->
+                !loopBlocks.contains(pred.getBlock()) ||
+                loopInvariantNodes.contains(pred)
+            );
+    }
+
+}

--- a/src/main/java/edu/kit/compiler/optimizations/analysis/LoopInvariantAnalysis.java
+++ b/src/main/java/edu/kit/compiler/optimizations/analysis/LoopInvariantAnalysis.java
@@ -2,7 +2,6 @@ package edu.kit.compiler.optimizations.analysis;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -41,10 +40,11 @@ public class LoopInvariantAnalysis {
     private Map<Block, Set<Block>> loops;
     /**
      * Map from loop entry point to nodes invariant to the represented loop. A
-     * node can be invariant to multiple loops.
+     * node can be invariant to multiple loops. The nodes invariant to each
+     * loop are in global postorder.
      */
     @Getter
-    private Map<Block, Set<Node>> loopInvariantNodes;
+    private Map<Block, List<Node>> loopInvariantNodes;
 
     /**
      * Analyze the given graph to find loop-invariant nodes.
@@ -65,7 +65,7 @@ public class LoopInvariantAnalysis {
             Block loopEntryPoint = loop.getKey();
             Set<Block> loopBlocks = loop.getValue();
 
-            Set<Node> invariantNodes = new HashSet<>();
+            List<Node> invariantNodes = new ArrayList<>();
             nodes.stream().filter(item -> loopBlocks.contains(item.getBlock())).forEach(node -> {
                 if (isLoopInvariant(node, loopBlocks, invariantNodes)) {
                     invariantNodes.add(node);
@@ -78,9 +78,9 @@ public class LoopInvariantAnalysis {
 
     /**
      * Whether a given node is invariant to the loop containing the given loop
-     * blocks given a set of nodes invariant to that loop.
+     * blocks given a list of nodes invariant to that loop.
      */
-    public boolean isLoopInvariant(Node node, Set<Block> loopBlocks, Set<Node> loopInvariantNodes) {
+    public boolean isLoopInvariant(Node node, Set<Block> loopBlocks, List<Node> loopInvariantNodes) {
         if (Util.isPinned(node)) {
             return false;
         } else if (node.getMode().equals(Mode.getX())) {

--- a/src/main/java/edu/kit/compiler/optimizations/analysis/LoopInvariantAnalysis.java
+++ b/src/main/java/edu/kit/compiler/optimizations/analysis/LoopInvariantAnalysis.java
@@ -8,9 +8,11 @@ import java.util.Map;
 import java.util.Set;
 
 import edu.kit.compiler.io.CommonUtil;
+import edu.kit.compiler.optimizations.Util;
 import edu.kit.compiler.optimizations.Util.NodeListFiller;
 
 import firm.Graph;
+import firm.Mode;
 import firm.nodes.Block;
 import firm.nodes.Node;
 import firm.nodes.Phi;
@@ -24,7 +26,8 @@ import lombok.RequiredArgsConstructor;
  * invariant to the representing loop. A node can be invariant to multiple
  * loops.
  * 
- * Control flow, memory and Phi nodes are never marked as invariant.
+ * This analysis respects the pin state of nodes. In addition, control flow and
+ * Phi nodes are never marked as invariant.
  */
 @RequiredArgsConstructor
 public class LoopInvariantAnalysis {
@@ -78,11 +81,11 @@ public class LoopInvariantAnalysis {
      * blocks given a set of nodes invariant to that loop.
      */
     public boolean isLoopInvariant(Node node, Set<Block> loopBlocks, Set<Node> loopInvariantNodes) {
-        if (node instanceof Phi) {
+        if (Util.isPinned(node)) {
             return false;
-        }
-
-        if (!node.getMode().isData()) {
+        } else if (node.getMode().equals(Mode.getX())) {
+            return false;
+        } else if (node instanceof Phi) {
             return false;
         }
 

--- a/src/main/java/edu/kit/compiler/optimizations/constant_folding/UndefinedCondStrategies.java
+++ b/src/main/java/edu/kit/compiler/optimizations/constant_folding/UndefinedCondStrategies.java
@@ -22,7 +22,7 @@ import lombok.Getter;
  * Collection of strategies for choosing a TargetValue for Cond nodes with an
  * unknown TargetValue.
  */
-public class UndefinedCondStrategies {
+public final class UndefinedCondStrategies {
 
     private UndefinedCondStrategies() {}
 

--- a/src/main/java/edu/kit/compiler/optimizations/loop_invariant/MoveInvariantStrategies.java
+++ b/src/main/java/edu/kit/compiler/optimizations/loop_invariant/MoveInvariantStrategies.java
@@ -1,0 +1,28 @@
+package edu.kit.compiler.optimizations.loop_invariant;
+
+import edu.kit.compiler.optimizations.LoopInvariantOptimization.MoveInvariantStrategy;
+
+import firm.nodes.Block;
+import firm.nodes.Node;
+
+/**
+ * Collection of strategies for deciding whether to move a loop-invariant node
+ * outside the loop.
+ */
+public final class MoveInvariantStrategies {
+
+    private MoveInvariantStrategies() {}
+
+    /**
+     * Strategy that moves all loop-invariant nodes.
+     */
+    public static class MoveAlways implements MoveInvariantStrategy {
+
+        @Override
+        public boolean decideMoveNodeTo(Node node, Block target) {
+            return true;
+        }
+
+    }
+
+}

--- a/src/test/java/edu/kit/compiler/optimizations/LoopAnalysisTest.java
+++ b/src/test/java/edu/kit/compiler/optimizations/LoopAnalysisTest.java
@@ -1,0 +1,671 @@
+package edu.kit.compiler.optimizations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import edu.kit.compiler.optimizations.analysis.LoopAnalysis;
+import edu.kit.compiler.transform.JFirmSingleton;
+
+import firm.Construction;
+import firm.Entity;
+import firm.Graph;
+import firm.MethodType;
+import firm.Mode;
+import firm.Program;
+import firm.TargetValue;
+import firm.Type;
+import firm.nodes.Block;
+import firm.nodes.Cond;
+import firm.nodes.Node;
+
+public class LoopAnalysisTest {
+
+    @BeforeAll
+    public static void setupAll() {
+        JFirmSingleton.initializeFirmLinux();
+    }
+
+    private Graph createGraph(Type[] returnTypes) {
+        UUID uuid = UUID.randomUUID();
+        MethodType methodType = new MethodType(new Type[] { }, returnTypes);
+        Entity entity = new Entity(Program.getGlobalType(), "test_" + uuid, methodType);
+        Graph graph = new Graph(entity, 0);
+
+        return graph;
+    }
+
+    @Test
+    public void testLinear() {
+        // Start -> A -> End
+        // =>
+        // no loop
+
+        // construct graph
+        Graph graph = createGraph(new Type[] { });
+        Construction construction = new Construction(graph);
+
+        Block block1 = construction.getCurrentBlock();
+        Node jmp1 = construction.newJmp();
+        block1.mature();
+
+        Block block2 = construction.newBlock();
+        block2.addPred(jmp1);
+        construction.setCurrentBlock(block2);
+        Node return2 = construction.newReturn(construction.getCurrentMem(), new Node[] { });
+        block2.mature();
+
+        Block block3 = graph.getEndBlock();
+        block3.addPred(return2);
+
+        construction.finish();
+
+        // run analysis
+        LoopAnalysis analysis = new LoopAnalysis(graph);
+        analysis.analyze();
+
+        // make assertions
+        assertTrue(analysis.getLoops().isEmpty());
+
+        assertEquals(Set.of(), analysis.getBlockLoops().get(block2));
+    }
+
+    @Test
+    public void testCond() {
+        //       -> A ->
+        // Start         C -> End
+        //       -> B ->
+        // =>
+        // no loop
+
+        // construct graph
+        Graph graph = createGraph(new Type[] { });
+        Construction construction = new Construction(graph);
+
+        Block block1 = construction.getCurrentBlock();
+        Node const1 = construction.newConst(TargetValue.getBTrue());
+        Node cond1 = construction.newCond(const1);
+        Node proj11 = construction.newProj(cond1, Mode.getX(), Cond.pnFalse);
+        Node proj12 = construction.newProj(cond1, Mode.getX(), Cond.pnTrue);
+        block1.mature();
+
+        Block block2 = construction.newBlock();
+        block2.addPred(proj11);
+        construction.setCurrentBlock(block2);
+        Node jmp2 = construction.newJmp();
+        block2.mature();
+
+        Block block3 = construction.newBlock();
+        block3.addPred(proj12);
+        construction.setCurrentBlock(block3);
+        Node jmp3 = construction.newJmp();
+        block3.mature();
+
+        Block block4 = construction.newBlock();
+        block4.addPred(jmp2);
+        block4.addPred(jmp3);
+        construction.setCurrentBlock(block4);
+        Node return4 = construction.newReturn(construction.getCurrentMem(), new Node[] { });
+        block4.mature();
+
+        Block block5 = graph.getEndBlock();
+        block5.addPred(return4);
+
+        construction.finish();
+
+        // run analysis
+        LoopAnalysis analysis = new LoopAnalysis(graph);
+        analysis.analyze();
+
+        // make assertions
+        assertTrue(analysis.getLoops().isEmpty());
+
+        Map<Block, Set<Block>> blockLoops = analysis.getBlockLoops();
+        assertEquals(Set.of(), blockLoops.get(block3));
+        assertEquals(Set.of(), blockLoops.get(block4));
+    }
+
+    @Test
+    public void testLoopEmpty() {
+        //          <->
+        // Start -> A    B -> End
+        //            ->
+        // =>
+        // loop header: A
+        // loop body: <empty>
+
+        // construct graph
+        Graph graph = createGraph(new Type[] { });
+        Construction construction = new Construction(graph);
+
+        Block block1 = construction.getCurrentBlock();
+        Node jmp1 = construction.newJmp();
+        block1.mature();
+
+        Block block2 = construction.newBlock();
+        block2.addPred(jmp1);
+        construction.setCurrentBlock(block2);
+        Node const2 = construction.newConst(TargetValue.getBTrue());
+        Node cond2 = construction.newCond(const2);
+        Node proj21 = construction.newProj(cond2, Mode.getX(), Cond.pnFalse);
+        Node proj22 = construction.newProj(cond2, Mode.getX(), Cond.pnTrue);
+        block2.addPred(proj22);
+        block2.mature();
+
+        Block block3 = construction.newBlock();
+        block3.addPred(proj21);
+        construction.setCurrentBlock(block3);
+        Node return3 = construction.newReturn(construction.getCurrentMem(), new Node[] { });
+        block3.mature();
+
+        Block block4 = graph.getEndBlock();
+        block4.addPred(return3);
+
+        construction.finish();
+
+        // run analysis
+        LoopAnalysis analysis = new LoopAnalysis(graph);
+        analysis.analyze();
+
+        Map<Block, Set<Block>> loops = analysis.getLoops();
+
+        // make assertions
+        assertEquals(1, loops.size());
+
+        assertTrue(loops.containsKey(block2));
+        assertEquals(Set.of(block2), loops.get(block2));
+
+        Map<Block, Set<Block>> blockLoops = analysis.getBlockLoops();
+        assertEquals(Set.of(block2), blockLoops.get(block2));
+        assertEquals(Set.of(), blockLoops.get(block3));
+    }
+
+    @Test
+    public void testLoopSingle() {
+        //            <-> B
+        // Start -> A
+        //             -> C -> End
+        // =>
+        // loop header: A
+        // loop body: B
+
+        // construct graph
+        Graph graph = createGraph(new Type[] { });
+        Construction construction = new Construction(graph);
+
+        Block block1 = construction.getCurrentBlock();
+        Node jmp1 = construction.newJmp();
+        block1.mature();
+
+        Block block2 = construction.newBlock();
+        block2.addPred(jmp1);
+        construction.setCurrentBlock(block2);
+        Node const2 = construction.newConst(TargetValue.getBTrue());
+        Node cond2 = construction.newCond(const2);
+        Node proj21 = construction.newProj(cond2, Mode.getX(), Cond.pnFalse);
+        Node proj22 = construction.newProj(cond2, Mode.getX(), Cond.pnTrue);
+
+        Block block3 = construction.newBlock();
+        block3.addPred(proj22);
+        construction.setCurrentBlock(block3);
+        Node jmp3 = construction.newJmp();
+        block3.mature();
+
+        block2.addPred(jmp3);
+        block2.mature();
+
+        Block block4 = construction.newBlock();
+        block4.addPred(proj21);
+        construction.setCurrentBlock(block4);
+        Node return4 = construction.newReturn(construction.getCurrentMem(), new Node[] { });
+        block4.mature();
+
+        Block block5 = graph.getEndBlock();
+        block5.addPred(return4);
+
+        construction.finish();
+
+        // run analysis
+        LoopAnalysis analysis = new LoopAnalysis(graph);
+        analysis.analyze();
+
+        Map<Block, Set<Block>> loops = analysis.getLoops();
+
+        // make assertions
+        assertEquals(1, loops.size());
+
+        assertTrue(loops.containsKey(block2));
+        assertEquals(Set.of(block2, block3), loops.get(block2));
+
+        Map<Block, Set<Block>> blockLoops = analysis.getBlockLoops();
+        assertEquals(Set.of(block2), blockLoops.get(block2));
+        assertEquals(Set.of(), blockLoops.get(block4));
+    }
+
+    @Test
+    public void testLoopMultiple() {
+        //            <------
+        //            -> B -> C
+        // Start -> A
+        //            -> D -> End
+        // =>
+        // loop header: A
+        // loop body: B, C
+
+        // construct graph
+        Graph graph = createGraph(new Type[] { });
+        Construction construction = new Construction(graph);
+
+        Block block1 = construction.getCurrentBlock();
+        Node jmp1 = construction.newJmp();
+        block1.mature();
+
+        Block block2 = construction.newBlock();
+        block2.addPred(jmp1);
+        construction.setCurrentBlock(block2);
+        Node const2 = construction.newConst(TargetValue.getBTrue());
+        Node cond2 = construction.newCond(const2);
+        Node proj21 = construction.newProj(cond2, Mode.getX(), Cond.pnFalse);
+        Node proj22 = construction.newProj(cond2, Mode.getX(), Cond.pnTrue);
+
+        Block block3 = construction.newBlock();
+        block3.addPred(proj22);
+        construction.setCurrentBlock(block3);
+        Node jmp3 = construction.newJmp();
+        block3.mature();
+
+        Block block4 = construction.newBlock();
+        block4.addPred(jmp3);
+        construction.setCurrentBlock(block4);
+        Node jmp4 = construction.newJmp();
+        block4.mature();
+
+        block2.addPred(jmp4);
+        block2.mature();
+
+        Block block5 = construction.newBlock();
+        block5.addPred(proj21);
+        construction.setCurrentBlock(block5);
+        Node return5 = construction.newReturn(construction.getCurrentMem(), new Node[] { });
+        block5.mature();
+
+        Block block6 = graph.getEndBlock();
+        block6.addPred(return5);
+
+        construction.finish();
+
+        // run analysis
+        LoopAnalysis analysis = new LoopAnalysis(graph);
+        analysis.analyze();
+
+        Map<Block, Set<Block>> loops = analysis.getLoops();
+
+        // make assertions
+        assertEquals(1, loops.size());
+
+        assertTrue(loops.containsKey(block2));
+        assertEquals(Set.of(block2, block3, block4), loops.get(block2));
+
+        Map<Block, Set<Block>> blockLoops = analysis.getBlockLoops();
+        assertEquals(Set.of(block2), blockLoops.get(block2));
+        assertEquals(Set.of(block2), blockLoops.get(block3));
+    }
+
+    @Test
+    public void testLoopCond() {
+        //                 -> C ->
+        //            -> B         E
+        //                 -> D ->
+        //            <-----------
+        // Start -> A
+        //            -> F -> End
+        // =>
+        // loop header: A
+        // loop body: B, C, D, E
+
+        // construct graph
+        Graph graph = createGraph(new Type[] { });
+        Construction construction = new Construction(graph);
+
+        Block block1 = construction.getCurrentBlock();
+        Node jmp1 = construction.newJmp();
+        block1.mature();
+
+        Block block2 = construction.newBlock();
+        block2.addPred(jmp1);
+        construction.setCurrentBlock(block2);
+        Node const2 = construction.newConst(TargetValue.getBTrue());
+        Node cond2 = construction.newCond(const2);
+        Node proj21 = construction.newProj(cond2, Mode.getX(), Cond.pnFalse);
+        Node proj22 = construction.newProj(cond2, Mode.getX(), Cond.pnTrue);
+
+        Block block3 = construction.newBlock();
+        block3.addPred(proj22);
+        construction.setCurrentBlock(block3);
+        Node const3 = construction.newConst(TargetValue.getBFalse());
+        Node cond3 = construction.newCond(const3);
+        Node proj31 = construction.newProj(cond3, Mode.getX(), Cond.pnFalse);
+        Node proj32 = construction.newProj(cond3, Mode.getX(), Cond.pnTrue);
+        block3.mature();
+
+        Block block4 = construction.newBlock();
+        block4.addPred(proj31);
+        construction.setCurrentBlock(block4);
+        Node jmp4 = construction.newJmp();
+        block4.mature();
+
+        Block block5 = construction.newBlock();
+        block5.addPred(proj32);
+        construction.setCurrentBlock(block5);
+        Node jmp5 = construction.newJmp();
+        block5.mature();
+
+        Block block6 = construction.newBlock();
+        block6.addPred(jmp4);
+        block6.addPred(jmp5);
+        construction.setCurrentBlock(block6);
+        Node jmp6 = construction.newJmp();
+        block6.mature();
+
+        block2.addPred(jmp6);
+        block2.mature();
+
+        Block block7 = construction.newBlock();
+        block7.addPred(proj21);
+        construction.setCurrentBlock(block7);
+        Node return7 = construction.newReturn(construction.getCurrentMem(), new Node[] { });
+        block7.mature();
+
+        Block block8 = graph.getEndBlock();
+        block8.addPred(return7);
+
+        construction.finish();
+
+        // run analysis
+        LoopAnalysis analysis = new LoopAnalysis(graph);
+        analysis.analyze();
+
+        Map<Block, Set<Block>> loops = analysis.getLoops();
+
+        // make assertions
+        assertEquals(1, loops.size());
+
+        assertTrue(loops.containsKey(block2));
+        assertEquals(Set.of(block2, block3, block4, block5, block6), loops.get(block2));
+
+        Map<Block, Set<Block>> blockLoops = analysis.getBlockLoops();
+        assertEquals(Set.of(block2), blockLoops.get(block4));
+        assertEquals(Set.of(block2), blockLoops.get(block5));
+        assertEquals(Set.of(block2), blockLoops.get(block6));
+    }
+
+    @Test
+    public void testLoopCondDirect() {
+        //            <--------
+        //                 -> C
+        //            -> B
+        //                 -> D
+        //            <--------
+        // Start -> A
+        //            -> E -> End
+        // =>
+        // loop header: A
+        // loop body: B, C, D
+
+        // construct graph
+        Graph graph = createGraph(new Type[] { });
+        Construction construction = new Construction(graph);
+
+        Block block1 = construction.getCurrentBlock();
+        Node jmp1 = construction.newJmp();
+        block1.mature();
+
+        Block block2 = construction.newBlock();
+        block2.addPred(jmp1);
+        construction.setCurrentBlock(block2);
+        Node const2 = construction.newConst(TargetValue.getBTrue());
+        Node cond2 = construction.newCond(const2);
+        Node proj21 = construction.newProj(cond2, Mode.getX(), Cond.pnFalse);
+        Node proj22 = construction.newProj(cond2, Mode.getX(), Cond.pnTrue);
+
+        Block block3 = construction.newBlock();
+        block3.addPred(proj22);
+        construction.setCurrentBlock(block3);
+        Node const3 = construction.newConst(TargetValue.getBFalse());
+        Node cond3 = construction.newCond(const3);
+        Node proj31 = construction.newProj(cond3, Mode.getX(), Cond.pnFalse);
+        Node proj32 = construction.newProj(cond3, Mode.getX(), Cond.pnTrue);
+        block3.mature();
+
+        Block block4 = construction.newBlock();
+        block4.addPred(proj31);
+        construction.setCurrentBlock(block4);
+        Node jmp4 = construction.newJmp();
+        block4.mature();
+
+        Block block5 = construction.newBlock();
+        block5.addPred(proj32);
+        construction.setCurrentBlock(block5);
+        Node jmp5 = construction.newJmp();
+        block5.mature();
+
+        block2.addPred(jmp4);
+        block2.addPred(jmp5);
+        block2.mature();
+
+        Block block6 = construction.newBlock();
+        block6.addPred(proj21);
+        construction.setCurrentBlock(block6);
+        Node return6 = construction.newReturn(construction.getCurrentMem(), new Node[] { });
+        block6.mature();
+
+        Block block7 = graph.getEndBlock();
+        block7.addPred(return6);
+
+        construction.finish();
+
+        // run analysis
+        LoopAnalysis analysis = new LoopAnalysis(graph);
+        analysis.analyze();
+
+        Map<Block, Set<Block>> loops = analysis.getLoops();
+
+        // make assertions
+        assertEquals(1, loops.size());
+
+        assertTrue(loops.containsKey(block2));
+        assertEquals(Set.of(block2, block3, block4, block5), loops.get(block2));
+
+        Map<Block, Set<Block>> blockLoops = analysis.getBlockLoops();
+        assertEquals(Set.of(block2), blockLoops.get(block4));
+        assertEquals(Set.of(block2), blockLoops.get(block5));
+    }
+
+    @Test
+    public void testLoopLoop() {
+        //                 -> C -> D
+        //            -> B <------
+        //                 -> E
+        //            <------
+        // Start -> A
+        //            -> F -> End
+        // =>
+        // loop header: A
+        // loop body: B, C, D, E
+        //
+        // loop header: B
+        // loop body C, D
+
+        // construct graph
+        Graph graph = createGraph(new Type[] { });
+        Construction construction = new Construction(graph);
+
+        Block block1 = construction.getCurrentBlock();
+        Node jmp1 = construction.newJmp();
+        block1.mature();
+
+        Block block2 = construction.newBlock();
+        block2.addPred(jmp1);
+        construction.setCurrentBlock(block2);
+        Node const2 = construction.newConst(TargetValue.getBTrue());
+        Node cond2 = construction.newCond(const2);
+        Node proj21 = construction.newProj(cond2, Mode.getX(), Cond.pnFalse);
+        Node proj22 = construction.newProj(cond2, Mode.getX(), Cond.pnTrue);
+
+        Block block3 = construction.newBlock();
+        block3.addPred(proj22);
+        construction.setCurrentBlock(block3);
+        Node const3 = construction.newConst(TargetValue.getBFalse());
+        Node cond3 = construction.newCond(const3);
+        Node proj31 = construction.newProj(cond3, Mode.getX(), Cond.pnFalse);
+        Node proj32 = construction.newProj(cond3, Mode.getX(), Cond.pnTrue);
+
+        Block block4 = construction.newBlock();
+        block4.addPred(proj32);
+        construction.setCurrentBlock(block4);
+        Node jmp4 = construction.newJmp();
+        block4.mature();
+
+        Block block5 = construction.newBlock();
+        block5.addPred(jmp4);
+        construction.setCurrentBlock(block5);
+        Node jmp5 = construction.newJmp();
+        block5.mature();
+
+        block3.addPred(jmp5);
+        block3.mature();
+
+        Block block6 = construction.newBlock();
+        block6.addPred(proj31);
+        construction.setCurrentBlock(block6);
+        Node jmp6 = construction.newJmp();
+        block6.mature();
+
+        block2.addPred(jmp6);
+        block2.mature();
+
+        Block block7 = construction.newBlock();
+        block7.addPred(proj21);
+        construction.setCurrentBlock(block7);
+        Node return7 = construction.newReturn(construction.getCurrentMem(), new Node[] { });
+        block7.mature();
+
+        Block block8 = graph.getEndBlock();
+        block8.addPred(return7);
+
+        construction.finish();
+
+        // run analysis
+        LoopAnalysis analysis = new LoopAnalysis(graph);
+        analysis.analyze();
+
+        Map<Block, Set<Block>> loops = analysis.getLoops();
+
+        // make assertions
+        assertEquals(2, loops.size());
+
+        assertTrue(loops.containsKey(block2));
+        assertEquals(Set.of(block2, block3, block4, block5, block6), loops.get(block2));
+
+        assertTrue(loops.containsKey(block3));
+        assertEquals(Set.of(block3, block4, block5), loops.get(block3));
+
+        Map<Block, Set<Block>> blockLoops = analysis.getBlockLoops();
+        assertEquals(Set.of(block2, block3), blockLoops.get(block4));
+        assertEquals(Set.of(block2), blockLoops.get(block6));
+    }
+
+    @Test
+    public void testLoopLoopDirect() {
+        //                  -> C -> D
+        //            <-> B <------
+        // Start -> A
+        //             -> E -> End
+        // =>
+        // loop header: A
+        // loop body: B, C, D
+        //
+        // loop header: B
+        // loop body C, D
+
+        // construct graph
+        Graph graph = createGraph(new Type[] { });
+        Construction construction = new Construction(graph);
+
+        Block block1 = construction.getCurrentBlock();
+        Node jmp1 = construction.newJmp();
+        block1.mature();
+
+        Block block2 = construction.newBlock();
+        block2.addPred(jmp1);
+        construction.setCurrentBlock(block2);
+        Node const2 = construction.newConst(TargetValue.getBTrue());
+        Node cond2 = construction.newCond(const2);
+        Node proj21 = construction.newProj(cond2, Mode.getX(), Cond.pnFalse);
+        Node proj22 = construction.newProj(cond2, Mode.getX(), Cond.pnTrue);
+
+        Block block3 = construction.newBlock();
+        block3.addPred(proj22);
+        construction.setCurrentBlock(block3);
+        Node const3 = construction.newConst(TargetValue.getBFalse());
+        Node cond3 = construction.newCond(const3);
+        Node proj31 = construction.newProj(cond3, Mode.getX(), Cond.pnFalse);
+        Node proj32 = construction.newProj(cond3, Mode.getX(), Cond.pnTrue);
+
+        block2.addPred(proj31);
+        block2.mature();
+
+        Block block4 = construction.newBlock();
+        block4.addPred(proj32);
+        construction.setCurrentBlock(block4);
+        Node jmp4 = construction.newJmp();
+        block4.mature();
+
+        Block block5 = construction.newBlock();
+        block5.addPred(jmp4);
+        construction.setCurrentBlock(block5);
+        Node jmp5 = construction.newJmp();
+        block5.mature();
+
+        block3.addPred(jmp5);
+        block3.mature();
+
+        Block block6 = construction.newBlock();
+        block6.addPred(proj21);
+        construction.setCurrentBlock(block6);
+        Node return6 = construction.newReturn(construction.getCurrentMem(), new Node[] { });
+        block6.mature();
+
+        Block block7 = graph.getEndBlock();
+        block7.addPred(return6);
+
+        construction.finish();
+
+        // run analysis
+        LoopAnalysis analysis = new LoopAnalysis(graph);
+        analysis.analyze();
+
+        Map<Block, Set<Block>> loops = analysis.getLoops();
+
+        // make assertions
+        assertEquals(2, loops.size());
+
+        assertTrue(loops.containsKey(block2));
+        assertEquals(Set.of(block2, block3, block4, block5), loops.get(block2));
+
+        assertTrue(loops.containsKey(block3));
+        assertEquals(Set.of(block3, block4, block5), loops.get(block3));
+
+        Map<Block, Set<Block>> blockLoops = analysis.getBlockLoops();
+        assertEquals(Set.of(block2), blockLoops.get(block2));
+        assertEquals(Set.of(block2, block3), blockLoops.get(block3));
+        assertEquals(Set.of(block2, block3), blockLoops.get(block4));
+    }
+
+}

--- a/src/test/java/edu/kit/compiler/optimizations/LoopInvariantOptimizationCallTest.java
+++ b/src/test/java/edu/kit/compiler/optimizations/LoopInvariantOptimizationCallTest.java
@@ -1,0 +1,182 @@
+package edu.kit.compiler.optimizations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.UUID;
+import java.util.function.BiFunction;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import edu.kit.compiler.transform.JFirmSingleton;
+
+import firm.bindings.binding_irdom;
+import firm.Construction;
+import firm.Entity;
+import firm.Graph;
+import firm.Ident;
+import firm.MethodType;
+import firm.Mode;
+import firm.PrimitiveType;
+import firm.Program;
+import firm.TargetValue;
+import firm.Type;
+import firm.nodes.Block;
+import firm.nodes.Call;
+import firm.nodes.Cond;
+import firm.nodes.Node;
+
+public class LoopInvariantOptimizationCallTest {
+
+    private static PrimitiveType INT_TYPE;
+    private static MethodType METHOD_TYPE;
+    private static Entity METHOD_ENTITY;
+
+    @BeforeAll
+    public static void setupAll() {
+        JFirmSingleton.initializeFirmLinux();
+
+        INT_TYPE = new PrimitiveType(Mode.getIs());
+
+        UUID uuid = UUID.randomUUID();
+        METHOD_TYPE = new MethodType(new Type[0], new Type[] { INT_TYPE });
+        METHOD_ENTITY = new Entity(Program.getGlobalType(), Ident.mangleGlobal("extern_" + uuid), METHOD_TYPE);
+    }
+
+    private Graph createGraph(Type[] returnTypes) {
+        UUID uuid = UUID.randomUUID();
+        MethodType methodType = new MethodType(new Type[] { }, returnTypes);
+        Entity entity = new Entity(Program.getGlobalType(), "test_" + uuid, methodType);
+        Graph graph = new Graph(entity, 0);
+
+        return graph;
+    }
+
+    /**
+     * @param createCall Function that receives the construction object and the
+     * initial memory as argument and returns a call node.
+     * @param makeAssertions Function that receives the block in which the call
+     * node was placed originally, as well as the call node itself. The return
+     * value is ignored.
+     */
+    private void genericTest(BiFunction<Construction, Node, Node> createCall, BiFunction<Block, Node, Object> makeAssertions) {
+        //            <-> B
+        // Start -> A
+        //             -> C -> End
+
+        // construct graph
+        Graph graph = createGraph(new Type[] { INT_TYPE });
+        Construction construction = new Construction(graph);
+
+        Block block1 = construction.getCurrentBlock();
+        Node mem1 = construction.getCurrentMem();
+        Node jmp1 = construction.newJmp();
+        block1.mature();
+
+        Block block2 = construction.newBlock();
+        block2.addPred(jmp1);
+        construction.setCurrentBlock(block2);
+        Node const21 = construction.newConst(TargetValue.getBTrue());
+        Node cond2 = construction.newCond(const21);
+        Node proj21 = construction.newProj(cond2, Mode.getX(), Cond.pnFalse);
+        Node proj22 = construction.newProj(cond2, Mode.getX(), Cond.pnTrue);
+
+        Block block3 = construction.newBlock();
+        block3.addPred(proj22);
+        construction.setCurrentBlock(block3);
+        Node call3 = createCall.apply(construction, mem1);
+        Node proj31 = construction.newProj(call3, Mode.getT(), Call.pnTResult);
+        Node proj32 = construction.newProj(proj31, Mode.getIs(), 0);
+        Node jmp3 = construction.newJmp();
+        block3.mature();
+
+        block2.addPred(jmp3);
+        construction.setCurrentBlock(block2);
+        Node const22 = construction.newConst(new TargetValue(1, Mode.getIs()));
+        Node phi2 = construction.newPhi(new Node[] { const22, proj32 }, Mode.getIs());
+        block2.mature();
+
+        Block block4 = construction.newBlock();
+        block4.addPred(proj21);
+        construction.setCurrentBlock(block4);
+        Node return4 = construction.newReturn(construction.getCurrentMem(), new Node[] { phi2 });
+        block4.mature();
+
+        Block block5 = graph.getEndBlock();
+        block5.addPred(return4);
+
+        construction.finish();
+
+        binding_irdom.compute_doms(graph.ptr);
+
+        // run optimization
+        LoopInvariantOptimization optimization = new LoopInvariantOptimization();
+        optimization.optimize(call3.getGraph(), null);
+
+        // make assertions
+        makeAssertions.apply(block3, call3);
+    }
+
+    @Test
+    public void testPinnedMemoryFunction() {
+        genericTest((construction, initialMem) -> {
+            Node address = construction.newAddress(METHOD_ENTITY);
+            return construction.newCall(construction.getCurrentMem(), address, new Node[0], METHOD_TYPE);
+        }, (loopBlock, call) -> {
+            assertEquals(loopBlock, call.getBlock());
+            return null;
+        });
+    }
+
+    @Test
+    public void testPinnedNoMemoryFunction() {
+        genericTest((construction, initialMem) -> {
+            Node address = construction.newAddress(METHOD_ENTITY);
+            return construction.newCall(construction.newNoMem(), address, new Node[0], METHOD_TYPE);
+        }, (loopBlock, call) -> {
+            assertEquals(loopBlock, call.getBlock());
+            return null;
+        });
+    }
+
+    @Test
+    public void testUnpinnedMemoryFunction() {
+        genericTest((construction, initialMem) -> {
+            Node address = construction.newAddress(METHOD_ENTITY);
+            Node call = construction.newCall(construction.getCurrentMem(), address, new Node[0], METHOD_TYPE);
+            Util.setPinned(call, false);
+            return call;
+        }, (loopBlock, call) -> {
+            assertEquals(loopBlock, call.getBlock());
+            return null;
+        });
+    }
+
+    @Test
+    public void testUnpinnedNoMemoryFunction() {
+        genericTest((construction, initialMem) -> {
+            Node address = construction.newAddress(METHOD_ENTITY);
+            Node call = construction.newCall(construction.newNoMem(), address, new Node[0], METHOD_TYPE);
+            Util.setPinned(call, false);
+            return call;
+        }, (loopBlock, call) -> {
+            assertNotEquals(loopBlock, call.getBlock());
+            return null;
+        });
+    }
+
+    @Test
+    public void testUnpinnedOutsideLoopMemoryFunction() {
+        genericTest((construction, initialMem) -> {
+            Node address = construction.newAddress(METHOD_ENTITY);
+            Node call = construction.newCall(initialMem, address, new Node[0], METHOD_TYPE);
+            Util.setPinned(call, false);
+            return call;
+        }, (loopBlock, call) -> {
+            assertNotEquals(loopBlock, call.getBlock());
+            return null;
+        });
+    }
+
+}

--- a/src/test/java/edu/kit/compiler/optimizations/LoopInvariantOptimizationTest.java
+++ b/src/test/java/edu/kit/compiler/optimizations/LoopInvariantOptimizationTest.java
@@ -1,0 +1,530 @@
+package edu.kit.compiler.optimizations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import edu.kit.compiler.transform.JFirmSingleton;
+
+import firm.bindings.binding_irdom;
+import firm.Construction;
+import firm.Entity;
+import firm.Graph;
+import firm.MethodType;
+import firm.Mode;
+import firm.PrimitiveType;
+import firm.Program;
+import firm.Relation;
+import firm.TargetValue;
+import firm.Type;
+import firm.nodes.Block;
+import firm.nodes.Cond;
+import firm.nodes.Node;
+
+public class LoopInvariantOptimizationTest {
+
+    private static PrimitiveType INT_TYPE;
+
+    @BeforeAll
+    public static void setupAll() {
+        JFirmSingleton.initializeFirmLinux();
+
+        INT_TYPE = new PrimitiveType(Mode.getIs());
+    }
+
+    private Graph createGraph(Type[] returnTypes) {
+        UUID uuid = UUID.randomUUID();
+        MethodType methodType = new MethodType(new Type[] { }, returnTypes);
+        Entity entity = new Entity(Program.getGlobalType(), "test_" + uuid, methodType);
+        Graph graph = new Graph(entity, 0);
+
+        return graph;
+    }
+
+    @Test
+    public void testSimple() {
+        //            <-> B
+        // Start -> A
+        //             -> C -> End
+
+        // construct graph
+        Graph graph = createGraph(new Type[] { INT_TYPE, INT_TYPE });
+        Construction construction = new Construction(graph);
+
+        Block block1 = construction.getCurrentBlock();
+        Node jmp1 = construction.newJmp();
+        block1.mature();
+
+        Block block2 = construction.newBlock();
+        block2.addPred(jmp1);
+        construction.setCurrentBlock(block2);
+        Node const21 = construction.newConst(TargetValue.getBTrue());
+        Node cond2 = construction.newCond(const21);
+        Node proj21 = construction.newProj(cond2, Mode.getX(), Cond.pnFalse);
+        Node proj22 = construction.newProj(cond2, Mode.getX(), Cond.pnTrue);
+
+        Block block3 = construction.newBlock();
+        block3.addPred(proj22);
+        construction.setCurrentBlock(block3);
+        Node const31 = construction.newConst(new TargetValue(42, Mode.getIs()));
+        Node const32 = construction.newConst(new TargetValue(73, Mode.getIs()));
+        Node add3 = construction.newAdd(const31, const32);
+        Node const33 = construction.newConst(new TargetValue(1, Mode.getIs()));
+        Node sub3 = construction.newSub(construction.newBad(Mode.getIs()), const33);
+        Node jmp3 = construction.newJmp();
+        block3.mature();
+
+        block2.addPred(jmp3);
+        construction.setCurrentBlock(block2);
+        Node const22 = construction.newConst(new TargetValue(17, Mode.getIs()));
+        Node phi21 = construction.newPhi(new Node[] { const22, sub3 }, Mode.getIs());
+        sub3.setPred(0, phi21);
+        Node const23 = construction.newConst(new TargetValue(1, Mode.getIs()));
+        Node phi22 = construction.newPhi(new Node[] { const23, add3 }, Mode.getIs());
+        block2.mature();
+
+        Block block4 = construction.newBlock();
+        block4.addPred(proj21);
+        construction.setCurrentBlock(block4);
+        Node return4 = construction.newReturn(construction.getCurrentMem(), new Node[] { phi21, phi22 });
+        block4.mature();
+
+        Block block5 = graph.getEndBlock();
+        block5.addPred(return4);
+
+        construction.finish();
+
+        binding_irdom.compute_doms(graph.ptr);
+
+        // run optimization
+        LoopInvariantOptimization optimization = new LoopInvariantOptimization();
+        optimization.optimize(graph, null);
+
+        // make assertions
+        assertEquals(block2, cond2.getBlock());
+        assertEquals(block2, phi21.getBlock());
+        assertEquals(block2, phi22.getBlock());
+
+        assertEquals(block1, add3.getBlock());
+        assertEquals(block3, sub3.getBlock());
+    }
+
+    @Test
+    public void testChain() {
+        //            <-> B
+        // Start -> A
+        //             -> C -> End
+
+        // construct graph
+        Graph graph = createGraph(new Type[] { INT_TYPE });
+        Construction construction = new Construction(graph);
+
+        Block block1 = construction.getCurrentBlock();
+        Node jmp1 = construction.newJmp();
+        block1.mature();
+
+        Block block2 = construction.newBlock();
+        block2.addPred(jmp1);
+        construction.setCurrentBlock(block2);
+        Node const21 = construction.newConst(TargetValue.getBTrue());
+        Node cond2 = construction.newCond(const21);
+        Node proj21 = construction.newProj(cond2, Mode.getX(), Cond.pnFalse);
+        Node proj22 = construction.newProj(cond2, Mode.getX(), Cond.pnTrue);
+
+        Block block3 = construction.newBlock();
+        block3.addPred(proj22);
+        construction.setCurrentBlock(block3);
+        Node const31 = construction.newConst(new TargetValue(42, Mode.getIs()));
+        Node const32 = construction.newConst(new TargetValue(73, Mode.getIs()));
+        Node add3 = construction.newAdd(const31, const32);
+        Node const33 = construction.newConst(new TargetValue(1, Mode.getIs()));
+        Node sub3 = construction.newSub(add3, const33);
+        Node jmp3 = construction.newJmp();
+        block3.mature();
+
+        block2.addPred(jmp3);
+        construction.setCurrentBlock(block2);
+        Node const22 = construction.newConst(new TargetValue(0, Mode.getIs()));
+        Node phi2 = construction.newPhi(new Node[] { const22, sub3 }, Mode.getIs());
+        block2.mature();
+
+        Block block4 = construction.newBlock();
+        block4.addPred(proj21);
+        construction.setCurrentBlock(block4);
+        Node return4 = construction.newReturn(construction.getCurrentMem(), new Node[] { phi2 });
+        block4.mature();
+
+        Block block5 = graph.getEndBlock();
+        block5.addPred(return4);
+
+        construction.finish();
+
+        binding_irdom.compute_doms(graph.ptr);
+
+        // run optimization
+        LoopInvariantOptimization optimization = new LoopInvariantOptimization();
+        optimization.optimize(graph, null);
+
+        // make assertions
+        assertEquals(block2, cond2.getBlock());
+        assertEquals(block2, phi2.getBlock());
+
+        assertEquals(block1, add3.getBlock());
+        assertEquals(block1, sub3.getBlock());
+    }
+
+    @Test
+    public void testHeader() {
+        //            <-> B
+        // Start -> A
+        //             -> C -> End
+
+        // construct graph
+        Graph graph = createGraph(new Type[] { INT_TYPE, INT_TYPE });
+        Construction construction = new Construction(graph);
+
+        Block block1 = construction.getCurrentBlock();
+        Node jmp1 = construction.newJmp();
+        block1.mature();
+
+        Block block2 = construction.newBlock();
+        block2.addPred(jmp1);
+        construction.setCurrentBlock(block2);
+        Node const21 = construction.newConst(new TargetValue(42, Mode.getIs()));
+        Node const22 = construction.newConst(new TargetValue(73, Mode.getIs()));
+        Node add2 = construction.newAdd(const21, const22);
+        Node const23 = construction.newConst(new TargetValue(17, Mode.getIs()));
+        Node const24 = construction.newConst(new TargetValue(1, Mode.getIs()));
+        Node sub2 = construction.newSub(construction.newBad(Mode.getIs()), const24);
+        Node const25 = construction.newConst(TargetValue.getBTrue());
+        Node cond2 = construction.newCond(const25);
+        Node proj21 = construction.newProj(cond2, Mode.getX(), Cond.pnFalse);
+        Node proj22 = construction.newProj(cond2, Mode.getX(), Cond.pnTrue);
+
+        Block block3 = construction.newBlock();
+        block3.addPred(proj22);
+        construction.setCurrentBlock(block3);
+        Node jmp3 = construction.newJmp();
+        block3.mature();
+
+        block2.addPred(jmp3);
+        construction.setCurrentBlock(block2);
+        Node phi2 = construction.newPhi(new Node[] { const23, sub2 }, Mode.getIs());
+        sub2.setPred(0, phi2);
+        block2.mature();
+
+        Block block4 = construction.newBlock();
+        block4.addPred(proj21);
+        construction.setCurrentBlock(block4);
+        Node return4 = construction.newReturn(construction.getCurrentMem(), new Node[] { add2, phi2 });
+        block4.mature();
+
+        Block block5 = graph.getEndBlock();
+        block5.addPred(return4);
+
+        construction.finish();
+
+        binding_irdom.compute_doms(graph.ptr);
+
+        // run optimization
+        LoopInvariantOptimization optimization = new LoopInvariantOptimization();
+        optimization.optimize(graph, null);
+
+        // make assertions
+        assertEquals(block2, cond2.getBlock());
+        assertEquals(block2, phi2.getBlock());
+
+        assertEquals(block1, add2.getBlock());
+        assertEquals(block2, sub2.getBlock());
+    }
+
+    @Test
+    public void testCond() {
+        //            <--------
+        //                 -> C
+        //            -> B
+        //                 -> D
+        //            <--------
+        // Start -> A
+        //            -> E -> End
+
+        // construct graph
+        Graph graph = createGraph(new Type[] { INT_TYPE, INT_TYPE });
+        Construction construction = new Construction(graph);
+
+        Block block1 = construction.getCurrentBlock();
+        Node jmp1 = construction.newJmp();
+        block1.mature();
+
+        Block block2 = construction.newBlock();
+        block2.addPred(jmp1);
+        construction.setCurrentBlock(block2);
+        Node const21 = construction.newConst(new TargetValue(10, Mode.getIs()));
+        Node cmp2 = construction.newCmp(construction.newBad(Mode.getIs()), const21, Relation.Less);
+        Node cond2 = construction.newCond(cmp2);
+        Node proj21 = construction.newProj(cond2, Mode.getX(), Cond.pnFalse);
+        Node proj22 = construction.newProj(cond2, Mode.getX(), Cond.pnTrue);
+
+        Block block3 = construction.newBlock();
+        block3.addPred(proj22);
+        construction.setCurrentBlock(block3);
+        Node const31 = construction.newConst(new TargetValue(111, Mode.getIs()));
+        Node const32 = construction.newConst(new TargetValue(113, Mode.getIs()));
+        Node cmp3 = construction.newCmp(const31, const32, Relation.Equal);
+        Node cond3 = construction.newCond(cmp3);
+        Node proj31 = construction.newProj(cond3, Mode.getX(), Cond.pnFalse);
+        Node proj32 = construction.newProj(cond3, Mode.getX(), Cond.pnTrue);
+        block3.mature();
+
+        Block block4 = construction.newBlock();
+        block4.addPred(proj31);
+        construction.setCurrentBlock(block4);
+        Node const41 = construction.newConst(new TargetValue(42, Mode.getIs()));
+        Node const42 = construction.newConst(new TargetValue(73, Mode.getIs()));
+        Node add4 = construction.newAdd(const41, const42);
+        Node jmp4 = construction.newJmp();
+        block4.mature();
+
+        Block block5 = construction.newBlock();
+        block5.addPred(proj32);
+        construction.setCurrentBlock(block5);
+        Node const51 = construction.newConst(new TargetValue(1, Mode.getIs()));
+        Node sub5 = construction.newSub(construction.newBad(Mode.getIs()), const51);
+        Node jmp5 = construction.newJmp();
+        block5.mature();
+
+        block2.addPred(jmp4);
+        block2.addPred(jmp5);
+        construction.setCurrentBlock(block2);
+        Node const22 = construction.newConst(new TargetValue(17, Mode.getIs()));
+        Node phi21 = construction.newPhi(new Node[] { const22, construction.newBad(Mode.getIs()), sub5 }, Mode.getIs());
+        phi21.setPred(1, phi21);
+        sub5.setPred(0, phi21);
+        cmp2.setPred(0, phi21);
+        Node const23 = construction.newConst(new TargetValue(1, Mode.getIs()));
+        Node phi22 = construction.newPhi(new Node[] { const23, add4, construction.newBad(Mode.getIs()) }, Mode.getIs());
+        phi22.setPred(2, phi22);
+        block2.mature();
+
+        Block block6 = construction.newBlock();
+        block6.addPred(proj21);
+        construction.setCurrentBlock(block6);
+        Node return6 = construction.newReturn(construction.getCurrentMem(), new Node[] { phi21, phi22 });
+        block6.mature();
+
+        Block block7 = graph.getEndBlock();
+        block7.addPred(return6);
+
+        construction.finish();
+
+        binding_irdom.compute_doms(graph.ptr);
+
+        // run optimization
+        LoopInvariantOptimization optimization = new LoopInvariantOptimization();
+        optimization.optimize(graph, null);
+
+        // make assertions
+        assertEquals(block2, cond2.getBlock());
+        assertEquals(block2, phi21.getBlock());
+        assertEquals(block2, phi22.getBlock());
+        assertEquals(block3, cond3.getBlock());
+
+        assertEquals(block2, cmp2.getBlock());
+        assertEquals(block1, cmp3.getBlock());
+        assertEquals(block1, add4.getBlock());
+        assertEquals(block5, sub5.getBlock());
+    }
+
+    @Test
+    public void testMultiplePredecessors() {
+        //            -> B ->   <-> E
+        // Start -> A         D
+        //            -> C ->    -> F -> End
+
+        // construct graph
+        Graph graph = createGraph(new Type[] { INT_TYPE, INT_TYPE });
+        Construction construction = new Construction(graph);
+
+        Block block1 = construction.getCurrentBlock();
+        Node jmp1 = construction.newJmp();
+        block1.mature();
+
+        Block block2 = construction.newBlock();
+        block2.addPred(jmp1);
+        construction.setCurrentBlock(block2);
+        Node const2 = construction.newConst(TargetValue.getBTrue());
+        Node cond2 = construction.newCond(const2);
+        Node proj21 = construction.newProj(cond2, Mode.getX(), Cond.pnFalse);
+        Node proj22 = construction.newProj(cond2, Mode.getX(), Cond.pnTrue);
+        block2.mature();
+
+        Block block3 = construction.newBlock();
+        block3.addPred(proj21);
+        construction.setCurrentBlock(block3);
+        Node jmp3 = construction.newJmp();
+        block3.mature();
+
+        Block block4 = construction.newBlock();
+        block4.addPred(proj22);
+        construction.setCurrentBlock(block4);
+        Node jmp4 = construction.newJmp();
+        block4.mature();
+
+        Block block5 = construction.newBlock();
+        block5.addPred(jmp3);
+        block5.addPred(jmp4);
+        construction.setCurrentBlock(block5);
+        Node const51 = construction.newConst(TargetValue.getBFalse());
+        Node cond5 = construction.newCond(const51);
+        Node proj51 = construction.newProj(cond5, Mode.getX(), Cond.pnFalse);
+        Node proj52 = construction.newProj(cond5, Mode.getX(), Cond.pnTrue);
+
+        Block block6 = construction.newBlock();
+        block6.addPred(proj52);
+        construction.setCurrentBlock(block6);
+        Node const61 = construction.newConst(new TargetValue(42, Mode.getIs()));
+        Node const62 = construction.newConst(new TargetValue(73, Mode.getIs()));
+        Node add6 = construction.newAdd(const61, const62);
+        Node const63 = construction.newConst(new TargetValue(1, Mode.getIs()));
+        Node sub6 = construction.newSub(construction.newBad(Mode.getIs()), const63);
+        Node jmp6 = construction.newJmp();
+        block6.mature();
+
+        block5.addPred(jmp6);
+        construction.setCurrentBlock(block5);
+        Node const52 = construction.newConst(new TargetValue(17, Mode.getIs()));
+        Node phi51 = construction.newPhi(new Node[] { const52, const52, sub6 }, Mode.getIs());
+        sub6.setPred(0, phi51);
+        Node const53 = construction.newConst(new TargetValue(1, Mode.getIs()));
+        Node phi52 = construction.newPhi(new Node[] { const53, const53, add6 }, Mode.getIs());
+        block5.mature();
+
+        Block block7 = construction.newBlock();
+        block7.addPred(proj51);
+        construction.setCurrentBlock(block7);
+        Node return7 = construction.newReturn(construction.getCurrentMem(), new Node[] { phi51, phi52 });
+        block7.mature();
+
+        Block block8 = graph.getEndBlock();
+        block8.addPred(return7);
+
+        construction.finish();
+
+        binding_irdom.compute_doms(graph.ptr);
+
+        // run optimization
+        LoopInvariantOptimization optimization = new LoopInvariantOptimization();
+        optimization.optimize(graph, null);
+
+        // make assertions
+        assertEquals(block5, cond5.getBlock());
+        assertEquals(block5, phi51.getBlock());
+        assertEquals(block5, phi52.getBlock());
+
+        assertEquals(block2, add6.getBlock());
+        assertEquals(block6, sub6.getBlock());
+    }
+
+    @Test
+    public void testInnerLoop() {
+        //                 <-> C
+        //            <-> B
+        // Start -> A
+        //             -> D -> End
+
+        // construct graph
+        Graph graph = createGraph(new Type[] { INT_TYPE, INT_TYPE, INT_TYPE });
+        Construction construction = new Construction(graph);
+
+        Block block1 = construction.getCurrentBlock();
+        Node jmp1 = construction.newJmp();
+        block1.mature();
+
+        Block block2 = construction.newBlock();
+        block2.addPred(jmp1);
+        construction.setCurrentBlock(block2);
+        Node const21 = construction.newConst(TargetValue.getBTrue());
+        Node cond2 = construction.newCond(const21);
+        Node proj21 = construction.newProj(cond2, Mode.getX(), Cond.pnFalse);
+        Node proj22 = construction.newProj(cond2, Mode.getX(), Cond.pnTrue);
+
+        Block block3 = construction.newBlock();
+        block3.addPred(proj22);
+        construction.setCurrentBlock(block3);
+        Node const3 = construction.newConst(TargetValue.getBFalse());
+        Node cond3 = construction.newCond(const3);
+        Node proj31 = construction.newProj(cond3, Mode.getX(), Cond.pnFalse);
+        Node proj32 = construction.newProj(cond3, Mode.getX(), Cond.pnTrue);
+
+        Block block4 = construction.newBlock();
+        block4.addPred(proj32);
+        construction.setCurrentBlock(block4);
+        Node const41 = construction.newConst(new TargetValue(42, Mode.getIs()));
+        Node const42 = construction.newConst(new TargetValue(73, Mode.getIs()));
+        Node add4 = construction.newAdd(const41, const42);
+        Node const43 = construction.newConst(new TargetValue(1, Mode.getIs()));
+        Node sub4 = construction.newSub(construction.newBad(Mode.getIs()), const43);
+        Node const44 = construction.newConst(new TargetValue(2, Mode.getIs()));
+        Node mul4 = construction.newMul(construction.newBad(Mode.getIs()), const44);
+        Node jmp4 = construction.newJmp();
+        block4.mature();
+
+        block3.addPred(jmp4);
+        construction.setCurrentBlock(block3);
+        Node phi31 = construction.newPhi(new Node[] { construction.newBad(Mode.getIs()), sub4 }, Mode.getIs());
+        Node phi32 = construction.newPhi(new Node[] { construction.newBad(Mode.getIs()), add4 }, Mode.getIs());
+        Node phi33 = construction.newPhi(new Node[] { construction.newBad(Mode.getIs()), mul4 }, Mode.getIs());
+        mul4.setPred(0, phi33);
+        block3.mature();
+
+        block2.addPred(proj31);
+        construction.setCurrentBlock(block2);
+        Node const22 = construction.newConst(new TargetValue(17, Mode.getIs()));
+        Node phi21 = construction.newPhi(new Node[] { const22, phi31 }, Mode.getIs());
+        sub4.setPred(0, phi21);
+        phi31.setPred(0, phi21);
+        Node const23 = construction.newConst(new TargetValue(1, Mode.getIs()));
+        Node phi22 = construction.newPhi(new Node[] { const23, phi32 }, Mode.getIs());
+        phi32.setPred(0, phi22);
+        Node const24 = construction.newConst(new TargetValue(2, Mode.getIs()));
+        Node phi23 = construction.newPhi(new Node[] { const24, phi33 }, Mode.getIs());
+        phi33.setPred(0, phi23);
+        block2.mature();
+
+        Block block5 = construction.newBlock();
+        block5.addPred(proj21);
+        construction.setCurrentBlock(block5);
+        Node return5 = construction.newReturn(construction.getCurrentMem(), new Node[] { phi21, phi22, phi23 });
+        block5.mature();
+
+        Block block6 = graph.getEndBlock();
+        block6.addPred(return5);
+
+        construction.finish();
+
+        binding_irdom.compute_doms(graph.ptr);
+
+        // run optimization
+        LoopInvariantOptimization optimization = new LoopInvariantOptimization();
+        optimization.optimize(graph, null);
+
+        // make assertions
+        assertEquals(block2, cond2.getBlock());
+        assertEquals(block2, phi21.getBlock());
+        assertEquals(block2, phi22.getBlock());
+        assertEquals(block2, phi23.getBlock());
+
+        assertEquals(block3, cond3.getBlock());
+        assertEquals(block3, phi31.getBlock());
+        assertEquals(block3, phi32.getBlock());
+        assertEquals(block3, phi33.getBlock());
+
+        assertEquals(block1, add4.getBlock());
+        assertEquals(block2, sub4.getBlock());
+        assertEquals(block4, mul4.getBlock());
+    }
+
+}


### PR DESCRIPTION
Adds an optimization that moves loop-invariant nodes in front of the loop (to the deepest common dominator of the loop entry point predecessors). In nested loops, nodes are moved out as far as possible. Currently, only data nodes are moved (except Phis), but const/pure (? @g4rgoil) functions could be added, if applicable.