### PR TITLE
Fix minor issue in semantic checks

### DIFF
--- a/mjtest-files/semantic/UnresolvedVariable.invalid.java
+++ b/mjtest-files/semantic/UnresolvedVariable.invalid.java
@@ -1,0 +1,5 @@
+class UnresolvedVariable {
+    public static void main(String[] args) {
+        System.out.println(bar);
+    }
+}

--- a/src/main/java/edu/kit/compiler/semantic/SemanticChecks.java
+++ b/src/main/java/edu/kit/compiler/semantic/SemanticChecks.java
@@ -184,8 +184,8 @@ class MethodCheckVisitor implements AstVisitor<Boolean> {
     }
 
     public Boolean visit(IdentifierExpressionNode expr) {
-        if (isMain && !expr.isHasError() && expr.getDefinition()
-                .getKind() == DefinitionKind.Parameter) {
+        if (isMain && !expr.isHasError()
+                && expr.getDefinition().getKind() == DefinitionKind.Parameter) {
             errorHandler.receive(new SemanticError(expr,
                 "accessing method parameters not allowed in main"));
         }

--- a/src/main/java/edu/kit/compiler/semantic/SemanticChecks.java
+++ b/src/main/java/edu/kit/compiler/semantic/SemanticChecks.java
@@ -184,7 +184,8 @@ class MethodCheckVisitor implements AstVisitor<Boolean> {
     }
 
     public Boolean visit(IdentifierExpressionNode expr) {
-        if (isMain && expr.getDefinition().getKind() == DefinitionKind.Parameter) {
+        if (isMain && !expr.isHasError() && expr.getDefinition()
+                .getKind() == DefinitionKind.Parameter) {
             errorHandler.receive(new SemanticError(expr,
                 "accessing method parameters not allowed in main"));
         }


### PR DESCRIPTION
Fixes a bug, where a `NullPointerException` could occur during semantic checks, if an unresolved identifier was used in the main method of a program.