### PR TITLE
Adjust inlining heuristic

### DIFF
--- a/src/main/java/edu/kit/compiler/optimizations/inlining/InliningOptimization.java
+++ b/src/main/java/edu/kit/compiler/optimizations/inlining/InliningOptimization.java
@@ -136,7 +136,7 @@ public class InliningOptimization implements Optimization.Local {
             logWeight += 3;
         }
         boolean doInline = logWeight >= 3 || (
-                (Math.pow(2, logWeight) * InliningStateTracker.UNPROBLEMATIC_SIZE_INCREASE / 2) >= entry.getNumNodes()
+                (Math.pow(2, logWeight) * InliningStateTracker.UNPROBLEMATIC_SIZE_INCREASE) >= entry.getNumNodes()
                         && logWeight >= 0
         );
         if (doInline) {

--- a/src/main/java/edu/kit/compiler/optimizations/inlining/InliningStateTracker.java
+++ b/src/main/java/edu/kit/compiler/optimizations/inlining/InliningStateTracker.java
@@ -12,13 +12,13 @@ public class InliningStateTracker {
     /**
      * Heuristic value for constant overhead of calls (number of firm nodes).
      */
-    public static final int CALL_OVERHEAD = 20;
+    public static final int CALL_OVERHEAD = 25;
 
     /**
      * Some heuristic values for per-function size increase limits (number of firm nodes).
      */
-    public static final int ACCEPTABLE_SIZE_INCREASE = 300;
-    public static final int UNPROBLEMATIC_SIZE_INCREASE = 80;
+    public static final int ACCEPTABLE_SIZE_INCREASE = 500;
+    public static final int UNPROBLEMATIC_SIZE_INCREASE = 150;
     public static final double ACCEPTABLE_INCREASE_FACTOR = 2;
     public static final int LARGE_FN = 500;
     public static final int UPPER_LIMIT_FN_SIZE = 6000;


### PR DESCRIPTION
Makes the inliner much more likely to decide that a function is worth to be inlined (basically, only quite large functions with no constant argument will be rejected by the heuristic now). The limits for acceptable function size increase are also increased, but not by too much, thus the worst case compile time shouldn't be affected much.