### PR TITLE
Fix issue in handling of temporary registers

### DIFF
--- a/src/main/java/edu/kit/compiler/register_allocation/ApplyAssignment.java
+++ b/src/main/java/edu/kit/compiler/register_allocation/ApplyAssignment.java
@@ -117,6 +117,13 @@ public class ApplyAssignment {
         assert instr.getType() == InstructionType.GENERAL;
         tracker.enterInstruction(index);
 
+        if (instr.getOverwriteRegister().isPresent()) {
+            Optional<Register> tRegister = assignment[instr.getTargetRegister().get()].getRegister();
+            // the overwrite register will be moved into the target register, thus any value in the
+            // target register is no longer available
+            tRegister.ifPresent(r -> tracker.getRegisters().clearTmp(r));
+        }
+
         List<Register> tmpRegisters = tracker.getTmpRegisters(
                 countRequiredTmps(tracker, instr, index),
                 determineExcludedTmps(tracker, instr)


### PR DESCRIPTION
Fixes a bug where the register allocator assumed a value to be present that is actually overwritten.