### PR TITLE
Improve handling of Phis in loop variable analysis

### DIFF
--- a/mjtest-files/exec/unroller/MultiplePhis.java
+++ b/mjtest-files/exec/unroller/MultiplePhis.java
@@ -1,0 +1,33 @@
+class Main {
+    public static void main(String[] args) {
+        Main m = new Main();
+        System.out.println(m.constantStep());
+        System.out.println(m.conflictingStep());
+        System.out.println(m.multiplePhis());
+    }
+
+    public int constantStep() {
+        int i = 0;
+        while (i < 10) {
+            if (i < 5) { i = i + 1; } else { i = i + 1; }
+        }
+        return i;
+    }
+
+    public int conflictingStep() {
+        int i = 0;
+        while (i < 10) {
+            if (i < 5) { i = i + 2; } else { i = i + 1; }
+        }
+        return i;
+    }
+
+    public int multiplePhis() {
+        int i = 0;
+        while (i < 10) {
+            if (i < 5) { i = i + 1; } else { i = i + 1; }
+            if (i > 5) { i = i + 1; } else { i = i + 1; }
+        }
+        return i;
+    }
+}


### PR DESCRIPTION
Previously `Phi` nodes on any path of a loop variable would always result in a non-constant step value. This PR improves the handling of `Phi`s slightly, to allow for a limited number of cases to still detect a constant step value.