### PR TITLE
Fix nasty bug in register allocation/lifetime analysis

### DIFF
--- a/run_mjtests.sh
+++ b/run_mjtests.sh
@@ -4,7 +4,7 @@ echo "Reading path, copying files and running mjtest"
 
 export PATH=$PATH
 export JAVA_HOME=$JAVA_HOME
-export MJ_TIMEOUT=15
+export MJ_TIMEOUT=30
 export MJ_RUN='./run'
 
 # copy test files

--- a/src/main/java/edu/kit/compiler/register_allocation/ApplyAssignment.java
+++ b/src/main/java/edu/kit/compiler/register_allocation/ApplyAssignment.java
@@ -117,6 +117,13 @@ public class ApplyAssignment {
         assert instr.getType() == InstructionType.GENERAL;
         tracker.enterInstruction(index);
 
+        if (instr.getOverwriteRegister().isPresent()) {
+            Optional<Register> tRegister = assignment[instr.getTargetRegister().get()].getRegister();
+            // the overwrite register will be moved into the target register, thus any value in the
+            // target register is no longer available
+            tRegister.ifPresent(r -> tracker.getRegisters().clearTmp(r));
+        }
+
         List<Register> tmpRegisters = tracker.getTmpRegisters(
                 countRequiredTmps(tracker, instr, index),
                 determineExcludedTmps(tracker, instr)

--- a/src/main/java/edu/kit/compiler/register_allocation/LifetimeAnalysis.java
+++ b/src/main/java/edu/kit/compiler/register_allocation/LifetimeAnalysis.java
@@ -201,6 +201,10 @@ public class LifetimeAnalysis {
                         lifetimes[target] = new Lifetime(index, index + 1);
                         definitionNestingDepth[target] = stack.size();
                         firstInstruction[target] = Optional.of(instr);
+                    } else {
+                        // it is possible that the first assignment of the target is "wrongly" placed within a loop,
+                        // thus it is necessary to update the depth
+                        definitionNestingDepth[target] = Math.min(definitionNestingDepth[target], stack.size());
                     }
                     handleRegisterUsage(target, instr, stack);
 


### PR DESCRIPTION
It was possible that the wrong loop depth was assigned to a vRegister and thus the lifetime not extended correctly with regard to other loops