### PR TITLE
Fix issues related to loop unrolling

### DIFF
--- a/mjtest-files/exec/PureFunctionTerminates.inf.java
+++ b/mjtest-files/exec/PureFunctionTerminates.inf.java
@@ -1,0 +1,10 @@
+class Test {
+    public static void main(String[] args) {
+        while (true) {
+            int j = 0;
+            while (j < 999 && j < 1000) {
+                j = j + 1;
+            }
+        }
+    }
+}

--- a/mjtest-files/exec/unroller/HeaderPhiConst.java
+++ b/mjtest-files/exec/unroller/HeaderPhiConst.java
@@ -1,0 +1,12 @@
+class HeaderPhiConst {
+    public static void main(String[] args) {
+        int n = 3;
+        int x8 = 8;
+        int x9 = 9;
+        while (n > 0) {
+                x9 = x8;
+                n = n - 1;
+        }
+        System.out.println(x9);
+    }
+}

--- a/mjtest-files/exec/unroller/PrematureReturn.java
+++ b/mjtest-files/exec/unroller/PrematureReturn.java
@@ -1,0 +1,40 @@
+class Test {
+    public static void main(String[] args) {
+        System.out.println(new Test().hindex());
+        System.out.println(new Test().minimal());
+        System.out.println(new Test().unconditional());
+    }
+
+    public int hindex() {
+        int[] help = new int[2];
+        help[0] = 0;
+        help[1] = 0;
+
+        int i = 0;
+        while (i <= 1) {
+            if (i > help[i])
+                return i-1;
+            i = i + 1;
+        }
+        return 999;
+    }
+
+    public int minimal() {
+        int i = 0;
+        while (i < 10) {
+            if (i == 5) {
+                return 25;
+            }
+            i = i + 1;
+        }
+        return i;
+    }
+
+    public int unconditional() {
+        int i = 0;
+        while (i < 10) {
+            return 42;
+        }
+        return i;
+    }
+}

--- a/mjtest-files/exec/unroller/UnclosedLoop.java
+++ b/mjtest-files/exec/unroller/UnclosedLoop.java
@@ -1,15 +1,4 @@
 class Test {
-    /*
-    public static void main(String[] args) {
-        while (true) {
-            int j = 0;
-            while (j < 999 && j < 1000) {
-                j = j + 1;
-            }
-        }
-    }
-    */
-
     public static void main(String[] args) {
         int i = 0;
         while (i < 10) {

--- a/mjtest-files/exec/unroller/UnclosedLoop.java
+++ b/mjtest-files/exec/unroller/UnclosedLoop.java
@@ -1,0 +1,25 @@
+class Test {
+    /*
+    public static void main(String[] args) {
+        while (true) {
+            int j = 0;
+            while (j < 999 && j < 1000) {
+                j = j + 1;
+            }
+        }
+    }
+    */
+
+    public static void main(String[] args) {
+        int i = 0;
+        while (i < 10) {
+            int j = 0;
+            while (j < 999 && j < 1000) {
+                j = j + 1;
+            }
+
+            i = i + 1;
+        }
+        System.out.println(i);
+    }
+}

--- a/src/main/java/edu/kit/compiler/optimizations/PureFunctionOptimization.java
+++ b/src/main/java/edu/kit/compiler/optimizations/PureFunctionOptimization.java
@@ -26,13 +26,15 @@ public final class PureFunctionOptimization implements Optimization.Local {
         for (var call : collector.calls) {
             var attributes = analysis.getAttributes(Util.getCallee(call));
             
-            hasChanged |= attributes.isPure() && unpinCall(call);
+            if (attributes.isTerminates()) {
+                hasChanged |= attributes.isPure() && unpinCall(call);
 
-            hasChanged |= switch (attributes.getPurity()) {
-                case CONST -> handleConstCall(call);
-                case PURE -> handlePureCall(call, collector.usedCalls); 
-                default -> false;
-            };
+                hasChanged |= switch (attributes.getPurity()) {
+                    case CONST -> handleConstCall(call);
+                    case PURE -> handlePureCall(call, collector.usedCalls); 
+                    default -> false;
+                };
+            }
         }
 
         return hasChanged;

--- a/src/main/java/edu/kit/compiler/optimizations/unrolling/LoopAnalysis.java
+++ b/src/main/java/edu/kit/compiler/optimizations/unrolling/LoopAnalysis.java
@@ -95,6 +95,10 @@ public final class LoopAnalysis {
         return surroundingLoops;
     }
 
+    /**
+     * Returns the nearest surrounding loop of `block`, where `block` is not the
+     * header of that loop.
+     */
     private Loop findSurroundingLoop(Block block) {
         var dom = block.ptr;
         while ((dom = binding_irdom.get_Block_idom(dom)) != null) {
@@ -119,9 +123,6 @@ public final class LoopAnalysis {
                 var loop = surroundingLoops.get(block);
                 Util.forEachPredBlock(block, (predBlock, i) -> {
                     var predLoop = surroundingLoops.get(predBlock);
-                    if (predLoop == null) {
-                        return;
-                    }
                     if (predLoop != null && !predLoop.equals(loop)
                             && !predLoop.getHeader().equals(block)) {
                         // this CF edge is a jump from within a loop to a block

--- a/src/main/java/edu/kit/compiler/optimizations/unrolling/LoopAnalysis.java
+++ b/src/main/java/edu/kit/compiler/optimizations/unrolling/LoopAnalysis.java
@@ -2,8 +2,6 @@ package edu.kit.compiler.optimizations.unrolling;
 
 import static firm.bindings.binding_irgraph.ir_graph_properties_t.IR_GRAPH_PROPERTY_CONSISTENT_DOMINANCE;
 
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -22,6 +20,8 @@ import firm.nodes.Cond;
 import firm.nodes.Node;
 import firm.nodes.Proj;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.EqualsAndHashCode.Include;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -37,24 +37,16 @@ public final class LoopAnalysis {
      */
     private final Map<Block, Loop> loops = new HashMap<>();
 
-    public static LoopAnalysis apply(Graph graph) {
+    public static List<LoopTree> apply(Graph graph) {
         graph.assureProperties(IR_GRAPH_PROPERTY_CONSISTENT_DOMINANCE);
 
         var analysis = new LoopAnalysis();
-        try {
-            analysis.collectLoops(graph);
-        } catch (GraphNotReducibleException e) {
-            assert false : "Graphs in MiniJava should always be reducible";
-            analysis.loops.clear();
-        }
-        return analysis;
-    }
+        analysis.collectLoops(graph);
 
-    /**
-     * Returns a hierarchy of the loops found by this analysis.
-     */
-    public List<LoopTree> getForestOfLoops() {
-        return LoopTree.build(this);
+        var surroundingLoops = analysis.findSurroundingLoops(graph);
+        analysis.checkLoopsClosed(graph, surroundingLoops);
+
+        return LoopTreeBuilder.build(analysis, surroundingLoops);
     }
 
     private void collectLoops(Graph graph) {
@@ -63,10 +55,6 @@ public final class LoopAnalysis {
             public void visitBlock(Block block) {
                 Util.forEachPredBlock(block, (predBlock, i) -> {
                     if (isBackEdge(predBlock, block)) {
-                        if (!isRetreatingEdge(predBlock, block)) {
-                            throw new GraphNotReducibleException();
-                        }
-
                         // It is possible for multiple backedges to point to the
                         // same loop header
                         loops.computeIfAbsent(block, Loop::new).addBackEdge(i);
@@ -83,10 +71,66 @@ public final class LoopAnalysis {
     }
 
     /**
-     * An exception to indicate that a graph is not reducible. See "Compilers
-     * Principles, Techniques, and Tools" (Aho et al., Chapter 9.6.4).
+     * Returns a map of each block in the graph to its nearest surrounding loop.
+     * More formally, for each block B find a loop L such that B is contained
+     * in the body of L and and there is no Loop L' such that B is contained in
+     * the body of L' and the header of L' is not contained in the body of L.
      */
-    private static final class GraphNotReducibleException extends RuntimeException {
+    private Map<Block, Loop> findSurroundingLoops(Graph graph) {
+        var surroundingLoops = new HashMap<Block, Loop>();
+
+        graph.walkBlocksPostorder(new BlockWalker() {
+            @Override
+            public void visitBlock(Block block) {
+                var loop = findSurroundingLoop(block);
+                if (loop != null) {
+                    assert loop.body.contains(block);
+                    assert loops.values().stream().noneMatch(other -> other.body.contains(block)
+                            && loop.body.contains(other.header));
+                    surroundingLoops.put(block, loop);
+                }
+            }
+        });
+
+        return surroundingLoops;
+    }
+
+    private Loop findSurroundingLoop(Block block) {
+        var dom = block.ptr;
+        while ((dom = binding_irdom.get_Block_idom(dom)) != null) {
+            var loop = loops.get(new Block(dom));
+            if (loop != null && loop.body.contains(block)) {
+                return loop;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * For each loop, checks if it is closed, and invalidates the loop if not.
+     * A loop is said to be closed if there are no jumps from within the loop
+     * body to any block outside of the loop.
+     */
+    private void checkLoopsClosed(Graph graph, Map<Block, Loop> surroundingLoops) {
+        graph.walkBlocks(new BlockWalker() {
+            @Override
+            public void visitBlock(Block block) {
+                var loop = surroundingLoops.get(block);
+                Util.forEachPredBlock(block, (predBlock, i) -> {
+                    var predLoop = surroundingLoops.get(predBlock);
+                    if (predLoop == null) {
+                        return;
+                    }
+                    if (predLoop != null && !predLoop.equals(loop)
+                            && !predLoop.getHeader().equals(block)) {
+                        // this CF edge is a jump from within a loop to a block
+                        // that is not in the body or header of that loop
+                        predLoop.setInvalid();
+                    }
+                });
+            }
+        });
     }
 
     /**
@@ -98,18 +142,21 @@ public final class LoopAnalysis {
      * the body may have an arbitrary number of blocks. The header is never
      * part of the body.
      * 
-     * A loop is valid if it is a natural loop, i.e. the loop header must
-     * dominate every block of the loop body. Additionally, the header must
-     * contain a Cond node where exactly one case exists the loop. Any loop
-     * that does not fit this criteria is detected and marked as invalid.
-     * Only valid loop loops are considered for loop unrolling.
+     * Loops are considered valid if they fulfill every criteria listed below.
+     * Any loop that does not fit this criteria is detected and marked as
+     * invalid. Only valid loop loops are considered for loop unrolling.
      * 
-     * Common examples of invalid loops are infinite loops, where the loop
-     * header is exited via an unconditional jump to the loop body.
+     * - The loop header dominates every block in the body
+     * - There must be exactly one Cond in the header
+     * - Exactly one path of the header Cond must leave the loop
+     * - The loop must be "closed", i.e. there are no jumps from within the loop
+     * body that leave the loop (this also includes Returns in the loop body)
      */
     @ToString
-    public static final class Loop implements Comparable<Loop> {
+    @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+    public static final class Loop {
 
+        @Include
         @Getter
         private final Block header;
         private final boolean[] isBackEdge;
@@ -182,21 +229,6 @@ public final class LoopAnalysis {
                     collectBlocks(predBlock, false);
                 }
             });
-        }
-
-        /**
-         * An ordering for loops, based on whether the header of one loop is
-         * contained in the body of another.
-         */
-        @Override
-        public int compareTo(Loop other) {
-            if (other.body.contains(this.header)) {
-                return -1;
-            } else if (this.body.contains(other.header)) {
-                return 1;
-            } else {
-                return 0;
-            }
         }
 
         /**
@@ -288,51 +320,51 @@ public final class LoopAnalysis {
         @Getter
         private final List<LoopTree> children = new LinkedList<>();
 
-        private static List<LoopTree> build(LoopAnalysis analysis) {
-            // sort loops, outer loop before nested loops
-            var sortedLoops = new ArrayList<>(analysis.loops.values());
-            sortedLoops.sort(Comparator.reverseOrder());
+        private void addChild(LoopTree child) {
+            this.children.add(child);
+        }
+    }
 
-            var trees = new HashMap<Block, LoopTree>();
-            var roots = new LinkedList<LoopTree>();
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    private static final class LoopTreeBuilder {
 
-            for (var loop : sortedLoops) {
-                insertTree(roots, trees, loop);
+        private final Map<Block, Loop> surroundingLoops;
+
+        private final List<LoopTree> roots = new LinkedList<>();
+        private final Map<Loop, LoopTree> trees = new HashMap<>();
+
+        private static List<LoopTree> build(LoopAnalysis analysis,
+                Map<Block, Loop> surroundingLoops) {
+            var builder = new LoopTreeBuilder(surroundingLoops);
+
+            for (var loop : analysis.loops.values()) {
+                builder.addTreeIfAbsent(loop);
             }
 
-            return roots;
+            return builder.roots;
         }
 
-        private static void insertTree(List<LoopTree> roots,
-                Map<Block, LoopTree> trees, Loop loop) {
-            var dom = loop.getHeader().ptr;
+        private LoopTree addTreeIfAbsent(Loop loop) {
+            var existingTree = trees.get(loop);
+            if (existingTree == null) {
+                var newTree = new LoopTree(loop);
+                trees.put(loop, newTree);
 
-            while ((dom = binding_irdom.get_Block_idom(dom)) != null) {
-                var tree = trees.get(new Block(dom));
-                if (tree != null && tree.getLoop().contains(loop)) {
-                    var child = new LoopTree(loop);
-                    tree.children.add(child);
-                    trees.put(loop.getHeader(), child);
-                    return;
+                var surroundingLoop = surroundingLoops.get(loop.getHeader());
+                if (surroundingLoop == null) {
+                    roots.add(newTree);
+                } else {
+                    addTreeIfAbsent(surroundingLoop).addChild(newTree);
                 }
-            }
 
-            var root = new LoopTree(loop);
-            roots.add(root);
-            trees.put(loop.getHeader(), root);
+                return newTree;
+            } else {
+                return existingTree;
+            }
         }
     }
 
     private static boolean isBackEdge(Block tail, Block head) {
         return binding_irdom.block_dominates(head.ptr, tail.ptr) != 0;
-    }
-
-    private static boolean isRetreatingEdge(Block tail, Block head) {
-        var dom = tail.ptr;
-        while (dom != null && !dom.equals(head.ptr)) {
-            dom = binding_irdom.get_Block_idom(dom);
-        }
-
-        return new Block(dom).equals(head);
     }
 }

--- a/src/main/java/edu/kit/compiler/optimizations/unrolling/LoopUnroller.java
+++ b/src/main/java/edu/kit/compiler/optimizations/unrolling/LoopUnroller.java
@@ -120,8 +120,8 @@ public final class LoopUnroller {
     private void fixCopyHeader(Block header, NodeVec headerCopy) {
         Util.forEachPredBlock(header, (predBlock, i) -> {
             var bad = graph.newBad(Mode.getX());
-            if (loop.isBackEdge(i)) {
 
+            if (loop.isBackEdge(i)) {
                 var pred = header.getPred(i);
                 var predCopy = copies.get(pred);
 
@@ -150,7 +150,6 @@ public final class LoopUnroller {
         Util.forEachPredBlock(header, (predBlock, i) -> {
             if (loop.isBackEdge(i)) {
                 var predCopy = copies.get(header.getPred(i));
-                assert predCopy.get(nCopies - 1) != null;
                 header.setPred(i, predCopy.get(nCopies - 1));
             } else if (isFull) {
                 header.setPred(i, graph.newBad(Mode.getX()));
@@ -194,12 +193,14 @@ public final class LoopUnroller {
     }
 
     private void fixHeaderPhi(Phi phi) {
-        for (int i = 0; i < phi.getPredCount(); ++i) {
-            if (loop.isBackEdge(i)) {
-                var phiCopy = copies.get(phi);
-                var predCopy = copies.get(phi.getPred(i));
+        var phiCopy = copies.get(phi);
 
-                phiCopy.get(0).setPred(i, phi.getPred(i));
+        for (int i = 0; i < phi.getPredCount(); ++i) {
+            var pred = phi.getPred(i);
+            if (loop.isBackEdge(i) && loop.containsNode(pred)) {
+                var predCopy = copies.get(pred);
+
+                phiCopy.get(0).setPred(i, pred);
                 for (int j = 1; j < nCopies; ++j) {
                     phiCopy.get(j).setPred(i, predCopy.get(j - 1));
                 }

--- a/src/main/java/edu/kit/compiler/optimizations/unrolling/LoopUnroller.java
+++ b/src/main/java/edu/kit/compiler/optimizations/unrolling/LoopUnroller.java
@@ -21,6 +21,10 @@ import lombok.ToString;
 
 /**
  * Implements functionality to fully or partially unroll loops.
+ * 
+ * Note: This implementation can only handle closed loops. For closed loops,
+ * the assumption can be made that only nodes in the header are referenced from
+ * outside the loop. This makes rewiring the graph significantly less messy.
  */
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public final class LoopUnroller {

--- a/src/main/java/edu/kit/compiler/optimizations/unrolling/LoopVariableAnalysis.java
+++ b/src/main/java/edu/kit/compiler/optimizations/unrolling/LoopVariableAnalysis.java
@@ -27,9 +27,7 @@ public final class LoopVariableAnalysis {
     private static final TargetValueLatticeElement CONFLICTING = TargetValueLatticeElement.conflicting();
 
     public static Optional<FixedIterationLoop> apply(Loop loop) {
-        if (!loop.isValid()) {
-            return Optional.empty();
-        }
+        assert loop.isValid();
 
         var cond = loop.getCond();
         if (cond.getSelector().getOpCode() != ir_opcode.iro_Cmp) {


### PR DESCRIPTION
1. Fix a simple `NullPointerException` related to an incorrect assumption about `Phi`s in the loop header.
2. Only try to unroll _closed_ loops, i.e. loops that don't contain jumps that leave the loop in their body.

These fixes fully resolve the following two issues found in the review.

> - Falsche Ausgabe mit -O1
> ```java
> class test {
>     public static void main(String[] args) {
>         System.out.println(new test().hindex());
>     }
>     
>     public int hindex() {
>         int i = 0;
>                 int[] help = new int[2];
>         help[0] = 0;
>         help[1] = 0;
>                 i=0;
>         while (i <= 1) {
>             if (i>help[i]) return i-1;
>             i=i+1;
>         }
>         return 999;
>     }       
> }
> ```

>  - (Simon_164, Simon_165, licm)
> ```
> Exception in thread "main" java.lang.NullPointerException: Cannot invoke edu.kit.compiler.optimizations.unrolling.LoopUnroller$NodeVec.get(int)" because "predCopy" is null
>         at du.kit.compiler.optimizations.unrolling.LoopUnroller.fixHeaderPhi(LoopUnroller.java:204)
>         at edu.kit.compiler.optimizations.unrolling.LoopUnroller.fixHeaderPhis(LoopUnroller.java:191)
>         at edu.kit.compiler.optimizations.unrolling.LoopUnroller.unroll(LoopUnroller.java:94)
>         at edu.kit.compiler.optimizations.unrolling.LoopUnroller.unroll(LoopUnroller.java:68)
> ```
> ```java
> int n = 3;
> int x8 = 8;
> int x9 = 9;
> while (n > 0) {
>     x9 = x8;
>     n = n - 1;
> }
> System.out.println(x9);
> ```

The warning in the following example is also resolved. However the `while(true)` loop still disappears, which does not seem related to loop unrolling.

> - (Sorter)
> ```
>    Verify warning: Cond T[546:374](Sorter_main_4[144]): Cond node lacks false proj
>    error: verifier failed; trying to write assert graph and abort
> ```
> mit --compile-firm bei
> ```java
> while (true) {
>     int j = 0;
>     while (j < 999 && j < 1000) {
>         j = j + 1;
>     }
> }
> ```
