### PR TITLE
Fix a regression in the pure function optimization

### DIFF
--- a/mjtest-files/exec/PureFunctionTerminates.inf.java
+++ b/mjtest-files/exec/PureFunctionTerminates.inf.java
@@ -1,0 +1,10 @@
+class Test {
+    public static void main(String[] args) {
+        while (true) {
+            int j = 0;
+            while (j < 999 && j < 1000) {
+                j = j + 1;
+            }
+        }
+    }
+}

--- a/src/main/java/edu/kit/compiler/optimizations/PureFunctionOptimization.java
+++ b/src/main/java/edu/kit/compiler/optimizations/PureFunctionOptimization.java
@@ -26,13 +26,15 @@ public final class PureFunctionOptimization implements Optimization.Local {
         for (var call : collector.calls) {
             var attributes = analysis.getAttributes(Util.getCallee(call));
             
-            hasChanged |= attributes.isPure() && unpinCall(call);
+            if (attributes.isTerminates()) {
+                hasChanged |= attributes.isPure() && unpinCall(call);
 
-            hasChanged |= switch (attributes.getPurity()) {
-                case CONST -> handleConstCall(call);
-                case PURE -> handlePureCall(call, collector.usedCalls); 
-                default -> false;
-            };
+                hasChanged |= switch (attributes.getPurity()) {
+                    case CONST -> handleConstCall(call);
+                    case PURE -> handlePureCall(call, collector.usedCalls); 
+                    default -> false;
+                };
+            }
         }
 
         return hasChanged;


### PR DESCRIPTION
This bug was introduced as part of #161. The fix prevents the `while (true)` from _disappearing_ in the following snippet.

> ```java
> while (true) {
>     int j = 0;
>     while (j < 999 && j < 1000) {
>         j = j + 1;
>     }
> }
> ```