### PR TITLE
Fix endless recursion in unused args analysis

### DIFF
--- a/mjtest-files/exec/unusedArgs/AlphabeticalRegisterTransfer.java
+++ b/mjtest-files/exec/unusedArgs/AlphabeticalRegisterTransfer.java
@@ -1,0 +1,95 @@
+class AlphabeticalRegisterTransfer {
+
+    public static void main(String[] args) {
+        new AlphabeticalRegisterTransfer().aroundWeGo(0);
+    }
+
+    public void aroundWeGo(int param) {
+        int counter = 0;
+        int a = param;
+        int b = param + 1;
+        int c = param + 2;
+        int d = param + 3;
+        int e = param + 4;
+        int f = param + 5;
+        int g = param + 6;
+        int h = param + 7;
+        int i = param + 8;
+        int j = param + 9;
+        int k = param + 10;
+        int l = param + 11;
+        int m = param + 12;
+        int n = param + 13;
+        int o = param + 14;
+        int p = param + 15;
+        int q = param + 16;
+        int r = param + 17;
+        int s = param + 18;
+        int t = param + 19;
+        int u = param + 20;
+        int v = param + 21;
+        int w = param + 22;
+        int x = param + 23;
+        int y = param + 24;
+        int z = param + 25;
+
+        while (counter < 13) {
+            counter = counter + 1;
+            int tmp = a;
+            a = b;
+            b = c;
+            c = d;
+            d = e;
+            e = f;
+            f = g;
+            g = h;
+            h = i;
+            i = j;
+            j = k;
+            k = l;
+            l = m;
+            m = n;
+            n = o;
+            o = p;
+            p = q;
+            q = r;
+            r = s;
+            s = t;
+            t = u;
+            u = v;
+            v = w;
+            w = x;
+            x = y;
+            y = z;
+            z = tmp;
+
+            System.out.write(10);
+            System.out.println(a);
+            System.out.println(b);
+            System.out.println(c);
+            System.out.println(d);
+            System.out.println(e);
+            System.out.println(f);
+            System.out.println(g);
+            System.out.println(h);
+            System.out.println(i);
+            System.out.println(j);
+            System.out.println(k);
+            System.out.println(l);
+            System.out.println(m);
+            System.out.println(n);
+            System.out.println(o);
+            System.out.println(p);
+            System.out.println(q);
+            System.out.println(r);
+            System.out.println(s);
+            System.out.println(t);
+            System.out.println(u);
+            System.out.println(v);
+            System.out.println(w);
+            System.out.println(x);
+            System.out.println(y);
+            System.out.println(z);
+        }
+    }
+}


### PR DESCRIPTION
`UnusedArgumentsAnalysis` would run into a stack overflow, if an argument to a non-inlined function was part of a loop in that functions graph. 