### PR TITLE
Fix for target size in case of upcast to stack slot

### DIFF
--- a/mjtest-files/compile/RegAllocUpcastSize.mj
+++ b/mjtest-files/compile/RegAllocUpcastSize.mj
@@ -1,0 +1,21 @@
+class A {
+    public boolean[][] permutations;
+
+    public static void main(String[] args) {
+        A obj = new A();
+        obj.run();
+    }
+
+    public void run() {
+        init();
+    }
+
+    public void init() {
+        permutations = new boolean[10][];
+        int i = 0;
+        while (i < 10) {
+            permutations[i] = new boolean[10];
+            i = i + 1;
+        }
+    }
+}

--- a/src/main/java/edu/kit/compiler/register_allocation/ApplyAssignment.java
+++ b/src/main/java/edu/kit/compiler/register_allocation/ApplyAssignment.java
@@ -303,7 +303,7 @@ public class ApplyAssignment {
         if (isUpcast && !isSignedUpcast && assignment[target].isSpilled()) {
             // edge case: stack slot needs to be zeroed in case of unsigned upcast
             output("mov%c $0, %s # zero the target slot for upcast",
-                    targetSize.getSuffix(), getTarget);
+                    sizes[target].getSuffix(), getTarget);
         }
 
         // output the instruction itself


### PR DESCRIPTION
I think this is our first bug that primarily affects `-O0` (happens only for an unsigned upcast to a register that is spilled)